### PR TITLE
Create semester project collection

### DIFF
--- a/src/collections/SemesterProject.ts
+++ b/src/collections/SemesterProject.ts
@@ -1,0 +1,38 @@
+import { Status } from '@/types/StatusTypes'
+import type { CollectionConfig } from 'payload'
+
+export const SemesterProject: CollectionConfig = {
+  slug: 'semesterProject',
+  fields: [
+    {
+      name: 'number',
+      type: 'number',
+      required: false,
+    },
+    {
+      name: 'project',
+      type: 'relationship',
+      relationTo: 'project',
+      required: true,
+    },
+    // {
+    //   name: 'semester',
+    //   type: 'relationship',
+    //   relationTo: 'semester',
+    //   required: true,
+    // },
+    {
+      name: 'status',
+      type: 'select',
+      defaultValue: Status.Pending,
+      options: Object.values(Status),
+      required: true,
+    },
+    {
+      name: 'published',
+      type: 'checkbox',
+      defaultValue: false,
+      required: true,
+    },
+  ],
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     user: User;
     media: Media;
     project: Project;
+    semesterProject: SemesterProject;
     formQuestion: FormQuestion;
     formResponse: FormResponse;
     form: Form;
@@ -82,6 +83,7 @@ export interface Config {
     user: UserSelect<false> | UserSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     project: ProjectSelect<false> | ProjectSelect<true>;
+    semesterProject: SemesterProjectSelect<false> | SemesterProjectSelect<true>;
     formQuestion: FormQuestionSelect<false> | FormQuestionSelect<true>;
     formResponse: FormResponseSelect<false> | FormResponseSelect<true>;
     form: FormSelect<false> | FormSelect<true>;
@@ -178,6 +180,19 @@ export interface Project {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "semesterProject".
+ */
+export interface SemesterProject {
+  id: string;
+  number?: number | null;
+  project: string | Project;
+  status: 'pending' | 'accepted' | 'rejected';
+  published: boolean;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "formQuestion".
  */
 export interface FormQuestion {
@@ -235,6 +250,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'project';
         value: string | Project;
+      } | null)
+    | ({
+        relationTo: 'semesterProject';
+        value: string | SemesterProject;
       } | null)
     | ({
         relationTo: 'formQuestion';
@@ -338,6 +357,18 @@ export interface ProjectSelect<T extends boolean = true> {
   attachments?: T;
   deadline?: T;
   timestamp?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "semesterProject_select".
+ */
+export interface SemesterProjectSelect<T extends boolean = true> {
+  number?: T;
+  project?: T;
+  status?: T;
+  published?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,7 @@ import { Project } from './collections/Project'
 import { FormQuestion } from './collections/FormQuestion'
 import { Form } from './collections/Form'
 import { FormResponse } from './collections/FormResponse'
+import { SemesterProject } from './collections/SemesterProject'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -25,7 +26,7 @@ export default buildConfig({
       importMapFile: path.resolve(dirname) + '/app/payload/admin/importMap.js',
     },
   },
-  collections: [User, Media, Project, FormQuestion, FormResponse, Form],
+  collections: [User, Media, Project, SemesterProject, FormQuestion, FormResponse, Form],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Created SemesterProject collection. This collection holds a relation between the semesters and projects without having to store irrelevant fields in project. 

Since #43 was blocking this ticket, a field has been commented. #43 fixes this. 

Fixes #67 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

> [!NOTE]
> Semester doesn't show here as the field is commented out. 

<img width="1365" alt="Screenshot 2025-04-12 at 7 07 46 PM" src="https://github.com/user-attachments/assets/94270911-4759-41b3-96a4-a19c845738e6" />

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
