### PR TITLE
chore: use secrets for discord notification workflow

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v5.3.0
         with:
-          webhook-url: https://discord.com/api/webhooks/1356165401066733588/rTia_LQtMeV1BrFbIlfIdsYXYTDZUdzLhKRRZKEKl8BvABBlY4esz0ZeM8mawUgVhelV
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           content: '📣Pull request opened: ${{ github.event.pull_request.title }} | Link: [View Pull Request](${{ github.event.pull_request.html_url }})'
 
   pull_request_merged:
@@ -22,5 +22,5 @@ jobs:
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v5.3.0
         with:
-          webhook-url: https://discord.com/api/webhooks/1356165401066733588/rTia_LQtMeV1BrFbIlfIdsYXYTDZUdzLhKRRZKEKl8BvABBlY4esz0ZeM8mawUgVhelV
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           content: '✅Pull request merged: ${{ github.event.pull_request.title }}'


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Secrets have been updated to use `DISCORD_WEBHOOK_URL`. The web hook has also been deleted and replaced with a new one. 

<img width="799" alt="image" src="https://github.com/user-attachments/assets/d4c4ee22-6dcd-4781-b6c7-a3c99f690550" />

Fixes #70 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

As shown below, this workflow works!

![image](https://github.com/user-attachments/assets/662b8500-ab18-4325-ba2f-949d7fb82d82)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
