### PR TITLE
Setup CRUD for Semester Collection

### DIFF
--- a/src/app/api/my-route/route.test.ts
+++ b/src/app/api/my-route/route.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { GET } from '@/app/api/my-route/route'
-
-import dotenv from 'dotenv'
 import { clearCollection, testPayloadObject } from '@/test-config/utils'
-
-dotenv.config()
+import { GET } from '@/app/api/my-route/route'
 
 describe('get user count', () => {
   afterEach(async () => {

--- a/src/data-layer/adapters/Payload.ts
+++ b/src/data-layer/adapters/Payload.ts
@@ -1,0 +1,6 @@
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+export const payload = await getPayload({
+  config: configPromise,
+})

--- a/src/data-layer/adapters/Payload.ts
+++ b/src/data-layer/adapters/Payload.ts
@@ -1,6 +1,6 @@
-import { getPayload } from 'payload'
+import { getPayload, Payload } from 'payload'
 import configPromise from '@payload-config'
 
-export const payload = await getPayload({
+export const payload: Payload = await getPayload({
   config: configPromise,
 })

--- a/src/data-layer/adapters/Payload.ts
+++ b/src/data-layer/adapters/Payload.ts
@@ -1,6 +1,13 @@
 import { getPayload, Payload } from 'payload'
 import configPromise from '@payload-config'
+import { testPayloadObject } from '@/test-config/utils'
 
-export const payload: Payload = await getPayload({
+let payloadConfig = await getPayload({
   config: configPromise,
 })
+
+if (process.env.NODE_ENV === 'test') {
+  payloadConfig = testPayloadObject
+}
+
+export const payload: Payload = payloadConfig

--- a/src/data-layer/collections/Semester.ts
+++ b/src/data-layer/collections/Semester.ts
@@ -14,6 +14,7 @@ export const Semester: CollectionConfig = {
       name: 'projects',
       type: 'relationship',
       relationTo: 'semesterProject',
+      hasMany: true,
       required: true,
     },
     {

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -18,4 +18,38 @@ describe('Semester service tests', () => {
     })
     expect(newSemester).toEqual(fetchedSemester)
   })
+
+  it('should get a semester', async () => {
+    const newSemester = await semesterService.createSemester(semesterCreateMock)
+    const fetchedSemester = await semesterService.getSemester(newSemester.id)
+    expect(newSemester).toEqual(fetchedSemester)
+  })
+
+  it('should return undefined if semester does not exist', async () => {
+    const fetchedSemester = await semesterService.getSemester('nonexistent_id')
+    expect(fetchedSemester).toBeUndefined()
+  })
+
+  it('should update a semester', async () => {
+    const newSemester = await semesterService.createSemester(semesterCreateMock)
+    const updatedSemester = await semesterService.updateSemester(newSemester.id, {
+      name: 'Updated Semester',
+    })
+    expect(updatedSemester.name).toEqual('Updated Semester')
+  })
+
+  it('should delete a semester', async () => {
+    const newSemester = await semesterService.createSemester(semesterCreateMock)
+    await semesterService.deleteSemester(newSemester.id)
+    await expect(
+      testPayloadObject.findByID({
+        collection: 'semester',
+        id: newSemester.id,
+      }),
+    ).rejects.toThrow('Not Found')
+  })
+
+  it('should throw an error if semester does not exist', async () => {
+    await expect(semesterService.deleteSemester('nonexistent_id')).rejects.toThrow('Not Found')
+  })
 })

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { clearCollection, testPayloadObject } from '@/test-config/utils'
+import { SemesterService } from './SemesterService'
+import { semesterCreateMock } from '@/test-config/mocks/Semester.mock'
+
+describe('Semester service tests', () => {
+  const semesterService = new SemesterService()
+
+  afterEach(async () => {
+    await clearCollection(testPayloadObject, 'semester')
+  })
+
+  it('should create a semester', async () => {
+    const newSemester = await semesterService.createSemester(semesterCreateMock)
+    const fetchedSemester = await testPayloadObject.findByID({
+      collection: 'semester',
+      id: newSemester.id,
+    })
+    expect(newSemester).toEqual(fetchedSemester)
+  })
+})

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -1,0 +1,66 @@
+import { CreateSemesterData, UpdateSemesterData } from '@/types/collections'
+import { payload } from '../adapters/Payload'
+import { Semester } from '@/payload-types'
+
+export class SemesterService {
+  /**
+   * Creates a new semester document in the database.
+   *
+   * @param newSemester The new semester data object to create
+   * @returns The created semester document
+   */
+  public async createSemester(newSemester: CreateSemesterData): Promise<Semester> {
+    return await payload.create({
+      collection: 'semester',
+      data: newSemester,
+    })
+  }
+  /**
+   * Retrieves a semester document from the database by its ID.
+   *
+   * @param id The ID of the semester to retrieve
+   * @returns The retrieved semester document
+   */
+  public async getSemester(semesterID: string): Promise<Semester> {
+    const result = await payload.find({
+      collection: 'semester',
+      where: {
+        id: {
+          equals: semesterID,
+        },
+      },
+    })
+    return result.docs[0]
+  }
+
+  /**
+   * Updates a semester document in the database.
+   *
+   * @param semesterID The semester document ID to update
+   * @param updatedSemester The updated semester data object
+   * @returns The updated semester document
+   */
+  public async updateSemester(
+    semesterID: string,
+    updatedSemester: UpdateSemesterData,
+  ): Promise<Semester> {
+    const result = await payload.update({
+      collection: 'semester',
+      id: semesterID,
+      data: updatedSemester,
+    })
+    return result
+  }
+
+  /**
+   * Deletes a semester document from the database with target ID.
+   *
+   * @param semesterID The semester document ID for deletion
+   */
+  public async deleteSemester(semesterID: string): Promise<void> {
+    await payload.delete({
+      collection: 'semester',
+      id: semesterID,
+    })
+  }
+}

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -1,4 +1,4 @@
-import { CreateSemesterData, UpdateSemesterData } from '@/types/collections'
+import { CreateSemesterData, UpdateSemesterData } from '@/types/Collections'
 import { payload } from '../adapters/Payload'
 import { Semester } from '@/payload-types'
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -201,7 +201,7 @@ export interface SemesterProject {
 export interface Semester {
   id: string;
   name: string;
-  projects: string | SemesterProject;
+  projects: (string | SemesterProject)[];
   deadline: string;
   startDate: string;
   endDate: string;

--- a/src/test-config/mocks/Semester.mock.ts
+++ b/src/test-config/mocks/Semester.mock.ts
@@ -1,0 +1,10 @@
+import { CreateSemesterData } from '@/types/Collections'
+import { semesterProjectMock } from './SemesterProject.mock'
+
+export const semesterCreateMock: CreateSemesterData = {
+  name: 'Semester 2 2025',
+  projects: [semesterProjectMock],
+  deadline: new Date().toISOString(),
+  startDate: new Date().toISOString(),
+  endDate: new Date().toISOString(),
+}

--- a/src/test-config/mocks/SemesterProject.mock.ts
+++ b/src/test-config/mocks/SemesterProject.mock.ts
@@ -1,0 +1,22 @@
+import { SemesterProject } from '@/payload-types'
+import { CreateSemesterProjectData } from '@/types/Collections'
+import { ProjectStatus } from '@/types/project'
+
+export const semesterProjectMock: SemesterProject = {
+  id: '67ff38a56a35e1b6cf43a68b',
+  number: 1,
+  project: '67ff38a56a35e1b6cf43a68c',
+  semester: '67ff38a56a35e1b6cf43a68d',
+  status: ProjectStatus.Pending,
+  published: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+export const semesterProjectCreateMock: CreateSemesterProjectData = {
+  number: 1,
+  project: '67ff38a56a35e1b6cf43a68c',
+  semester: '67ff38a56a35e1b6cf43a68d',
+  status: ProjectStatus.Pending,
+  published: false,
+}

--- a/src/test-config/mocks/User.mock.ts
+++ b/src/test-config/mocks/User.mock.ts
@@ -1,4 +1,4 @@
-import { CreateUserData } from '@/types/collections'
+import { CreateUserData } from '@/types/Collections'
 import { UserRole } from '@/types/user'
 
 export const adminCreateMock: CreateUserData = {

--- a/src/types/Collections.ts
+++ b/src/types/Collections.ts
@@ -1,4 +1,4 @@
-import { Semester, User } from '@/payload-types'
+import { Semester, SemesterProject, User } from '@/payload-types'
 
 export type CreateUserData = Omit<User, 'id' | 'createdAt' | 'updatedAt'>
 
@@ -7,3 +7,8 @@ export type CreateUserData = Omit<User, 'id' | 'createdAt' | 'updatedAt'>
  */
 export type CreateSemesterData = Omit<Semester, 'id' | 'createdAt' | 'updatedAt'>
 export type UpdateSemesterData = Partial<CreateSemesterData>
+
+/*
+ * Semester Project Collection Types
+ */
+export type CreateSemesterProjectData = Omit<SemesterProject, 'id' | 'createdAt' | 'updatedAt'>

--- a/src/types/Collections.ts
+++ b/src/types/Collections.ts
@@ -1,0 +1,9 @@
+import { Semester, User } from '@/payload-types'
+
+export type CreateUserData = Omit<User, 'id' | 'createdAt' | 'updatedAt'>
+
+/*
+ * Semester Collection Types
+ */
+export type CreateSemesterData = Omit<Semester, 'id' | 'createdAt' | 'updatedAt'>
+export type UpdateSemesterData = Partial<CreateSemesterData>

--- a/src/types/collections.ts
+++ b/src/types/collections.ts
@@ -1,3 +1,0 @@
-import { User } from '@/payload-types'
-
-export type CreateUserData = Omit<User, 'id' | 'createdAt' | 'updatedAt'>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

This ticket creates the CRUD methods under the service layer for the `Semester` collection.

Also creates a payload adapter that exports either the actual config, or the test config, depending on the environment. 

`Semester` has been updated to take in a list of projects instead of a single relation. 

**Fixes** #83

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I have requested a review from another user
