### PR TITLE
fix: comment secure in state setting

### DIFF
--- a/src/app/api/auth/google/callback/route.test.ts
+++ b/src/app/api/auth/google/callback/route.test.ts
@@ -105,7 +105,7 @@ describe('GET /api/auth/google/callback', () => {
       maxAge: 3600,
       httpOnly: true,
       sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
+      // secure: process.env.NODE_ENV === 'production',
     })
   })
 

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -96,7 +96,7 @@ export const GET = async (req: NextRequest) => {
 
   cookieStore.set('auth_token', token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    // secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     maxAge: 60 * 60,
   })

--- a/src/app/api/auth/google/route.test.ts
+++ b/src/app/api/auth/google/route.test.ts
@@ -51,7 +51,7 @@ describe('Google Auth tests', async () => {
       maxAge: 60,
       httpOnly: true,
       sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
+      // secure: process.env.NODE_ENV === 'production',
     })
     expect(oauth2Client.generateAuthUrl).toHaveBeenCalledWith({
       scope: SCOPES_ARRAY_MOCK,

--- a/src/app/api/auth/google/route.test.ts
+++ b/src/app/api/auth/google/route.test.ts
@@ -50,7 +50,7 @@ describe('Google Auth tests', async () => {
     expect(mockSet).toHaveBeenCalledWith('state', STATE_MOCK, {
       maxAge: 60,
       httpOnly: true,
-      sameSite: 'strict',
+      sameSite: 'lax'
       // secure: process.env.NODE_ENV === 'production',
     })
     expect(oauth2Client.generateAuthUrl).toHaveBeenCalledWith({

--- a/src/app/api/auth/google/route.test.ts
+++ b/src/app/api/auth/google/route.test.ts
@@ -50,7 +50,7 @@ describe('Google Auth tests', async () => {
     expect(mockSet).toHaveBeenCalledWith('state', STATE_MOCK, {
       maxAge: 60,
       httpOnly: true,
-      sameSite: 'lax'
+      sameSite: 'lax',
       // secure: process.env.NODE_ENV === 'production',
     })
     expect(oauth2Client.generateAuthUrl).toHaveBeenCalledWith({

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -8,7 +8,7 @@ export const GET = async () => {
   // Set state to prevent CSRF attacks
   cookieStore.set('state', state, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    // secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     /**
      * Should be set at less than 10 minutes but for security, best for 60 seconds or less

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -9,7 +9,7 @@ export const GET = async () => {
   cookieStore.set('state', state, {
     httpOnly: true,
     // secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
+    sameSite: 'lax',
     /**
      * Should be set at less than 10 minutes but for security, best for 60 seconds or less
      * https://www.oauth.com/oauth2-servers/authorization/the-authorization-response/


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

We currently have secure enabled in cookies although our production doesn't actually have a certificate yet, therefore it's HTTP and not HTTPS.

Leaves tech debt as when we move to a proper site, we'll need to uncomment the lines.

**Fixes** #123

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/5353c24e-176c-4a22-b45a-7a9aa0be96b8)

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
