### PR TITLE
107-backend-create-admin-endpoint-to-delete-a-user

### DIFF
--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -211,7 +211,7 @@ describe('test /api/admin/users/[id]', () => {
     })
   })
 
-  describe('DELETE /api/admin/users/[id]', () => {
+  describe('tests DELETE /api/admin/users/[id]', () => {
     it('should delete a user', async () => {
       const newSemester = await userService.createUser(clientCreateMock)
       const res = await DELETE({} as NextRequest, {

--- a/src/app/api/admin/users/[id]/route.test.ts
+++ b/src/app/api/admin/users/[id]/route.test.ts
@@ -13,7 +13,7 @@ import {
   clientAdditionalInfoCreateMock,
   clientCreateMock,
 } from '@/test-config/mocks/User.mock'
-import { GET, PATCH } from '@/app/api/admin/users/[id]/route'
+import { GET, PATCH, DELETE } from '@/app/api/admin/users/[id]/route'
 import { NextRequest } from 'next/server'
 import { UserCombinedInfo } from '@/types/Collections'
 
@@ -208,6 +208,22 @@ describe('test /api/admin/users/[id]', () => {
       })
       expect(res.status).toBe(StatusCodes.NOT_FOUND)
       expect(await res.json()).toEqual({ error: 'User not found' })
+    })
+  })
+
+  describe('DELETE /api/admin/users/[id]', () => {
+    it('should delete a user', async () => {
+      const newSemester = await userService.createUser(clientCreateMock)
+      const res = await DELETE({} as NextRequest, {
+        params: paramsToPromise({ id: newSemester.id }),
+      })
+      expect(res.status).toBe(StatusCodes.NO_CONTENT)
+      await expect(userService.getUser(newSemester.id)).rejects.toThrow('Not Found')
+    })
+
+    it('should return a 404 error if the user does not exist', async () => {
+      const res = await DELETE({} as NextRequest, { params: paramsToPromise({ id: 'noid' }) })
+      expect(res.status).toBe(StatusCodes.NOT_FOUND)
     })
   })
 })

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -105,3 +105,31 @@ export const PATCH = async (
     )
   }
 }
+
+/**
+ * DELETE method to delete a user by Id.
+ *
+ * @param req The request object containing the request body
+ * @returns No content status code
+ */
+export const DELETE = async (
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params
+    const userService = new UserService()
+    await userService.deleteUser(id)
+    return new NextResponse(null, { status: StatusCodes.NO_CONTENT })
+  } catch (error) {
+    if (error instanceof NotFound) {
+      return NextResponse.json({ error: 'User not found' }, { status: StatusCodes.NOT_FOUND })
+    } else {
+      console.error(error)
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: StatusCodes.INTERNAL_SERVER_ERROR },
+      )
+    }
+  }
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -49,7 +49,6 @@ export const GET = async (
 
 /**
  * Updates a single user by ID if the request is made by an admin
- * Admins cannot update users with the role of admin
  *
  * @param param0 The ID of the user to update
  * @returns The updated user


### PR DESCRIPTION
# Description

Endpoint for Admin users to delete a user by ID created. Copy/pasted logic from #111 

**Fixes** #107 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

With invalid ID ❌
<img width="699" alt="Screenshot 2025-04-24 at 9 40 37 AM" src="https://github.com/user-attachments/assets/0ac541c0-4244-402a-ae81-4c49d80017f6" />

With valid ID ✅
<img width="671" alt="Screenshot 2025-04-24 at 9 40 16 AM" src="https://github.com/user-attachments/assets/4aed8459-fa17-4448-88ca-cab117709045" />


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have requested a review from another user
