### PR TITLE
165-backend-create-endpoint-for-clients-and-admins-to-fetch-form

### DIFF
--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -50,8 +50,8 @@ class RouteWrapper {
    * Updates a single user by ID if the request is made by an admin
    *
    * @param param0 The ID of the user to update
-   * @returns The updated user
    * @param _req
+   * @returns The updated user
    */
   @Security('jwt', ['admin'])
   static async PATCH(

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -9,7 +9,7 @@ class RouteWrapper {
   /**
    * Method to fetch all users
    *
-   * @param _req The Next Request context
+   * @param req The Next Request context
    * @param param1 The query parameters, including limit and cursor
    * @returns
    */

--- a/src/app/api/forms/route.test.ts
+++ b/src/app/api/forms/route.test.ts
@@ -19,6 +19,14 @@ describe('tests /api/forms', async () => {
       expect(await res.json()).toEqual({ error: 'No token provided' })
     })
 
+    it('return 401 when student sends request', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, studentToken)
+      await formService.createForm(formMock)
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect((await res.json()).error).toBe('No scope')
+    })
+
     it('return form when client sends request', async () => {
       cookieStore.set(AUTH_COOKIE_NAME, clientToken)
       await formService.createForm(formMock)

--- a/src/app/api/forms/route.test.ts
+++ b/src/app/api/forms/route.test.ts
@@ -1,0 +1,47 @@
+import { StatusCodes } from 'http-status-codes'
+import { cookies } from 'next/headers'
+
+import FormService from '@/data-layer/services/FormService'
+import { GET } from './route'
+import { createMockNextRequest } from '@/test-config/utils'
+import { formMock } from '@/test-config/mocks/Form.mock'
+import { AUTH_COOKIE_NAME } from '@/types/Auth'
+import { adminToken, clientToken, studentToken } from '@/test-config/routes-setup'
+
+describe('tests /api/forms', async () => {
+  const formService = new FormService()
+  const cookieStore = await cookies()
+
+  describe('GET /api/forms', () => {
+    it('return a 401 if not authenticated', async () => {
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms/'))
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect(await res.json()).toEqual({ error: 'No token provided' })
+    })
+
+    it('return form when client sends request', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, clientToken)
+      await formService.createForm(formMock)
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
+      expect(res.status).toBe(StatusCodes.OK)
+      const form = (await res.json()).data
+      expect(form.name).toEqual(formMock.name)
+    })
+
+    it('return form when admin sends request', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+      await formService.createForm(formMock)
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
+      expect(res.status).toBe(StatusCodes.OK)
+      const form = (await res.json()).data
+      expect(form.name).toEqual(formMock.name)
+    })
+
+    it('return 401 when student sends request', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, studentToken)
+      await formService.createForm(formMock)
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+    })
+  })
+})

--- a/src/app/api/forms/route.test.ts
+++ b/src/app/api/forms/route.test.ts
@@ -51,5 +51,12 @@ describe('tests /api/forms', async () => {
       const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
       expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
     })
+
+    it('return 404 when form not found', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
+      expect(res.status).toBe(StatusCodes.NOT_FOUND)
+      expect((await res.json()).error).toBe('Form not found')
+    })
   })
 })

--- a/src/app/api/forms/route.test.ts
+++ b/src/app/api/forms/route.test.ts
@@ -19,14 +19,6 @@ describe('tests /api/forms', async () => {
       expect(await res.json()).toEqual({ error: 'No token provided' })
     })
 
-    it('return 401 when student sends request', async () => {
-      cookieStore.set(AUTH_COOKIE_NAME, studentToken)
-      await formService.createForm(formMock)
-      const res = await GET(createMockNextRequest('http://localhost:3000/api/forms'))
-      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
-      expect((await res.json()).error).toBe('No scope')
-    })
-
     it('return form when client sends request', async () => {
       cookieStore.set(AUTH_COOKIE_NAME, clientToken)
       await formService.createForm(formMock)

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -17,9 +17,6 @@ class RouteWrapper {
     const formService = new FormService()
     try {
       const form = await formService.getForm()
-      if (!form) {
-        throw new NotFound(() => 'Form not found')
-      }
       return NextResponse.json({ data: form })
     } catch (error) {
       if (error instanceof NotFound) {

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import FormService from '@/data-layer/services/FormService'
+import { Security } from '@/business-layer/middleware/Security'
+
+class RouteWrapper {
+  /**
+   * GET Method to get form.
+   *
+   * @param _req The request object
+   * @returns One form.
+   */
+  @Security('jwt', ['admin', 'client'])
+  static async GET(_req: NextRequest) {
+    const formService = new FormService()
+    const form = await formService.getAllForms()
+    return NextResponse.json({ data: form })
+  }
+}
+
+export const GET = RouteWrapper.GET

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -13,7 +13,7 @@ class RouteWrapper {
   @Security('jwt', ['admin', 'client'])
   static async GET(_req: NextRequest) {
     const formService = new FormService()
-    const form = await formService.getAllForms()
+    const form = await formService.getForm()
     return NextResponse.json({ data: form })
   }
 }

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import FormService from '@/data-layer/services/FormService'
 import { Security } from '@/business-layer/middleware/Security'
+import { NotFound } from 'payload'
+import { StatusCodes } from 'http-status-codes'
 
 class RouteWrapper {
   /**
@@ -13,8 +15,21 @@ class RouteWrapper {
   @Security('jwt', ['admin', 'client'])
   static async GET(_req: NextRequest) {
     const formService = new FormService()
-    const form = await formService.getForm()
-    return NextResponse.json({ data: form })
+    try {
+      const form = await formService.getForm()
+      if (!form) {
+        throw new NotFound(() => 'Form not found')
+      }
+      return NextResponse.json({ data: form })
+    } catch (error) {
+      if (error instanceof NotFound) {
+        return NextResponse.json({ error: 'Form not found' }, { status: StatusCodes.NOT_FOUND })
+      }
+      return NextResponse.json(
+        { error: 'Internal Server Error' },
+        { status: StatusCodes.INTERNAL_SERVER_ERROR },
+      )
+    }
   }
 }
 

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -22,6 +22,7 @@ class RouteWrapper {
       if (error instanceof NotFound) {
         return NextResponse.json({ error: 'Form not found' }, { status: StatusCodes.NOT_FOUND })
       }
+      console.log(error)
       return NextResponse.json(
         { error: 'Internal Server Error' },
         { status: StatusCodes.INTERNAL_SERVER_ERROR },

--- a/src/data-layer/services/FormService.test.ts
+++ b/src/data-layer/services/FormService.test.ts
@@ -17,6 +17,12 @@ describe('Form service tests', () => {
       expect(newForm).toEqual(fetchedForm)
     })
 
+    it('fetches the form', async () => {
+      const createdForm = await formService.createForm(formMock)
+      const fetchedForm = await formService.getForm()
+      expect(fetchedForm).toEqual(createdForm)
+    })
+
     it('update a form by ID', async () => {
       const createdForm = await formService.createForm(formMock)
       const updatedForm = await formService.updateForm(createdForm.id, {

--- a/src/data-layer/services/FormService.test.ts
+++ b/src/data-layer/services/FormService.test.ts
@@ -53,6 +53,10 @@ describe('Form service tests', () => {
     it('not found - delete a form by nonexisting ID', async () => {
       await expect(formService.deleteForm('non-existing-id')).rejects.toThrow('Not Found')
     })
+
+    it('not found - fetch a form by nonexisting ID', async () => {
+      await expect(formService.getForm()).rejects.toThrow('Not Found')
+    })
   })
 
   describe('Form response service tests', () => {

--- a/src/data-layer/services/FormService.test.ts
+++ b/src/data-layer/services/FormService.test.ts
@@ -17,22 +17,6 @@ describe('Form service tests', () => {
       expect(newForm).toEqual(fetchedForm)
     })
 
-    it('find a form by ID', async () => {
-      const createdForm = await formService.createForm(formMock)
-      const fetchedForm = await formService.getForm(createdForm.id)
-      expect(fetchedForm).toEqual(createdForm)
-    })
-
-    it('find the one form by ID', async () => {
-      const createdForm = await formService.createForm(formMock)
-      const fetchedForm = await formService.getAllForms()
-      expect(fetchedForm).toEqual(createdForm)
-    })
-
-    it('not found - find form with nonexistent id', async () => {
-      await expect(formService.getForm('nonexistent_id')).rejects.toThrow('Not Found')
-    })
-
     it('update a form by ID', async () => {
       const createdForm = await formService.createForm(formMock)
       const updatedForm = await formService.updateForm(createdForm.id, {

--- a/src/data-layer/services/FormService.test.ts
+++ b/src/data-layer/services/FormService.test.ts
@@ -23,6 +23,12 @@ describe('Form service tests', () => {
       expect(fetchedForm).toEqual(createdForm)
     })
 
+    it('find the one form by ID', async () => {
+      const createdForm = await formService.createForm(formMock)
+      const fetchedForm = await formService.getAllForms()
+      expect(fetchedForm).toEqual(createdForm)
+    })
+
     it('not found - find form with nonexistent id', async () => {
       await expect(formService.getForm('nonexistent_id')).rejects.toThrow('Not Found')
     })

--- a/src/data-layer/services/FormService.ts
+++ b/src/data-layer/services/FormService.ts
@@ -29,11 +29,20 @@ export default class FormService {
    * @param formID The ID of the form to retrieve
    * @returns The retrieved form document
    */
+  // this method might be redundant? there is only one form
   public async getForm(formID: string): Promise<Form> {
     return await payload.findByID({
       collection: 'form',
       id: formID,
     })
+  }
+
+  public async getAllForms(): Promise<Form> {
+    return (
+      await payload.find({
+        collection: 'form',
+      })
+    ).docs[0]
   }
 
   /**

--- a/src/data-layer/services/FormService.ts
+++ b/src/data-layer/services/FormService.ts
@@ -30,14 +30,7 @@ export default class FormService {
    * @returns The retrieved form document
    */
   // this method might be redundant? there is only one form
-  public async getForm(formID: string): Promise<Form> {
-    return await payload.findByID({
-      collection: 'form',
-      id: formID,
-    })
-  }
-
-  public async getAllForms(): Promise<Form> {
+  public async getForm(): Promise<Form> {
     return (
       await payload.find({
         collection: 'form',

--- a/src/data-layer/services/FormService.ts
+++ b/src/data-layer/services/FormService.ts
@@ -8,6 +8,7 @@ import {
   CreateFormQuestionData,
 } from '@/types/Collections'
 import { payload } from '../adapters/Payload'
+import { NotFound } from 'payload'
 
 export default class FormService {
   /**
@@ -29,13 +30,16 @@ export default class FormService {
    * @param formID The ID of the form to retrieve
    * @returns The retrieved form document
    */
-  // this method might be redundant? there is only one form
   public async getForm(): Promise<Form> {
-    return (
+    const form = (
       await payload.find({
         collection: 'form',
       })
     ).docs[0]
+    if (!form) {
+      throw new NotFound(() => 'Not Found')
+    }
+    return form
   }
 
   /**


### PR DESCRIPTION
# Description

Created the GET method to fetch the form under `api/forms`
Relevant testing created, including no token, admin, client, student tokens

Postman testing has not been done - how to add auth into postman request?

Created getAllForms() under `FormService` to allow for no ID input - as there is only one form
Test for FormService.getAllForms() created

**Fixes** #165 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
