### PR TITLE
189 backend create backend endpoint for users to fetch their projects

### DIFF
--- a/src/app/api/users/me/projects/route.test.ts
+++ b/src/app/api/users/me/projects/route.test.ts
@@ -1,0 +1,49 @@
+import { StatusCodes } from 'http-status-codes'
+import { cookies } from 'next/headers'
+
+import { GET } from './route'
+import { createMockNextRequest } from '@/test-config/utils'
+import { AUTH_COOKIE_NAME } from '@/types/Auth'
+import { adminToken, clientToken, studentToken } from '@/test-config/routes-setup'
+import { adminMock } from '@/test-config/mocks/Auth.mock'
+import ProjectService from '@/data-layer/services/ProjectService'
+import { projectCreateMock } from '@/test-config/mocks/Project.mock'
+
+describe('tests /api/users/me/projects', async () => {
+  const projectService = new ProjectService()
+  const cookieStore = await cookies()
+
+  describe('GET /api/users/me/projects', () => {
+    it('should return a 401 if no user is authenticated', async () => {
+      const res = await GET(createMockNextRequest('/api/users/me/projects'))
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect((await res.json()).error).toBe('No token provided')
+    })
+
+    it('should return a 401 if the user is a student', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, studentToken)
+      const res = await GET(createMockNextRequest('/api/users/me/projects'))
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect((await res.json()).error).toBe('No scope')
+    })
+
+    it("should return user's project data", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+      const newProject = await projectService.createProject({
+        ...projectCreateMock,
+        clients: [adminMock.id],
+      })
+      const res = await GET(createMockNextRequest('/api/users/me/projects'))
+      expect(res.status).toBe(StatusCodes.OK)
+      expect((await res.json()).data).toEqual([newProject])
+    })
+
+    it('should not return projects not related to the user', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, clientToken)
+      await projectService.createProject(projectCreateMock)
+      const res = await GET(createMockNextRequest('/api/users/me/projects'))
+      expect(res.status).toBe(StatusCodes.OK)
+      expect((await res.json()).data).toEqual([])
+    })
+  })
+})

--- a/src/app/api/users/me/projects/route.ts
+++ b/src/app/api/users/me/projects/route.ts
@@ -1,0 +1,23 @@
+import { Security } from '@/business-layer/middleware/Security'
+import ProjectService from '@/data-layer/services/ProjectService'
+import { UserCombinedInfo } from '@/types/Collections'
+import { NextRequest, NextResponse } from 'next/server'
+
+class RouteWrapper {
+  /**
+   * Method to handle GET requests for a user's own projects.
+   *
+   * @param req The next request object containing the user information
+   * @returns The response object containing the user's projects
+   */
+  @Security('jwt', ['client', 'admin'])
+  static async GET(req: NextRequest & { user: UserCombinedInfo }) {
+    const { user } = req
+    const userID = user.id
+    const projectService = new ProjectService()
+    const projects = await projectService.getProjectsByClientId(userID)
+    return NextResponse.json({ data: projects.docs })
+  }
+}
+
+export const GET = RouteWrapper.GET

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -3,6 +3,12 @@ import { UserCombinedInfo } from '@/types/Collections'
 import { NextRequest, NextResponse } from 'next/server'
 
 class RouteWrapper {
+  /**
+   * GET request to get a user's own information
+   *
+   * @param req The next request containing the user information
+   * @returns The user's own information
+   */
   @Security('jwt')
   static async GET(req: NextRequest & { user: UserCombinedInfo }) {
     const { user } = req

--- a/src/data-layer/collections/FormResponse.ts
+++ b/src/data-layer/collections/FormResponse.ts
@@ -35,7 +35,9 @@ export const FormResponse: CollectionConfig = {
           },
         })
 
-        const nonClients = users.docs.filter((user) => user.role !== 'client')
+        const nonClients = users.docs.filter(
+          (user) => user.role !== 'client' && user.role !== 'admin',
+        )
 
         if (nonClients.length > 0) {
           const names = nonClients.map((u) => `${u.firstName} ${u.lastName}`).join(', ')

--- a/src/data-layer/collections/FormResponse.ts
+++ b/src/data-layer/collections/FormResponse.ts
@@ -35,9 +35,7 @@ export const FormResponse: CollectionConfig = {
           },
         })
 
-        const nonClients = users.docs.filter(
-          (user) => user.role !== 'client' && user.role !== 'admin',
-        )
+        const nonClients = users.docs.filter((user) => !['admin', 'client'].includes(user.role))
 
         if (nonClients.length > 0) {
           const names = nonClients.map((u) => `${u.firstName} ${u.lastName}`).join(', ')

--- a/src/data-layer/collections/Project.ts
+++ b/src/data-layer/collections/Project.ts
@@ -31,9 +31,7 @@ export const Project: CollectionConfig = {
           },
         })
 
-        const nonClients = users.docs.filter(
-          (user) => user.role !== 'client' && user.role !== 'admin',
-        )
+        const nonClients = users.docs.filter((user) => !['admin', 'client'].includes(user.role))
 
         if (nonClients.length > 0) {
           const names = nonClients.map((u) => `${u.firstName} ${u.lastName}`).join(', ')

--- a/src/data-layer/collections/Project.ts
+++ b/src/data-layer/collections/Project.ts
@@ -31,7 +31,9 @@ export const Project: CollectionConfig = {
           },
         })
 
-        const nonClients = users.docs.filter((user) => user.role !== 'client')
+        const nonClients = users.docs.filter(
+          (user) => user.role !== 'client' && user.role !== 'admin',
+        )
 
         if (nonClients.length > 0) {
           const names = nonClients.map((u) => `${u.firstName} ${u.lastName}`).join(', ')


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Implement GET /api/users/me/projects to fetch user's projects
- Add tests for authentication and project filtering logic
- Update filters to exclude both non-clients and non-admins

Fixes:

- Enable admins to also create projects, this used to be restricted to clients only
- Add JSDoc to previous route created

**Fixes** #189 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
