### PR TITLE
237 Refactor zod schemas to use datetime instead of string

### DIFF
--- a/src/test-config/routes-setup.ts
+++ b/src/test-config/routes-setup.ts
@@ -1,4 +1,4 @@
-import { clearCollection, testPayloadObject } from './utils'
+import { clearCollection } from './utils'
 import {
   ACCESS_TOKEN_MOCK,
   ADMIN_JWT_MOCK,
@@ -10,6 +10,8 @@ import {
   studentMock,
 } from './mocks/Auth.mock'
 import AuthService from '@/business-layer/services/AuthService'
+import { payload } from '@/data-layer/adapters/Payload'
+import { CollectionSlug } from 'payload'
 
 let adminToken: string
 let clientToken: string
@@ -67,15 +69,9 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await clearCollection(testPayloadObject, 'user')
-  await clearCollection(testPayloadObject, 'authentication')
-  await clearCollection(testPayloadObject, 'clientAdditionalInfo')
-  await clearCollection(testPayloadObject, 'semester')
-  await clearCollection(testPayloadObject, 'semesterProject')
-  await clearCollection(testPayloadObject, 'form')
-  await clearCollection(testPayloadObject, 'project')
-  await clearCollection(testPayloadObject, 'formQuestion')
-  await clearCollection(testPayloadObject, 'formResponse')
+  for (const slug of Object.keys(payload.collections)) {
+    await clearCollection(payload, slug as CollectionSlug)
+  }
   cookies = {}
 })
 

--- a/src/types/request-models/ProjectRequests.ts
+++ b/src/types/request-models/ProjectRequests.ts
@@ -13,15 +13,11 @@ export const UpdateProjectRequestBody = z.object({
   description: z.string().optional(),
   deadline: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
   timestamp: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
   clients: z
     .union([
@@ -37,13 +33,9 @@ export const CreateProjectRequestBody = z.object({
   description: z.string(),
   deadline: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
-  timestamp: z.string().refine((val) => !isNaN(Date.parse(val)), {
-    message: 'Invalid date format, should be in ISO 8601 format',
-  }),
+  timestamp: z.string().datetime({ message: 'Invalid date format, should be in ISO 8601 format' }),
   clients: z.union([
     z.array(z.string()).nonempty('At least one client is required'),
     z.array(UserSchema).nonempty('At least one client is required'),

--- a/src/types/request-models/SemesterRequests.ts
+++ b/src/types/request-models/SemesterRequests.ts
@@ -5,34 +5,22 @@ export const UpdateSemesterRequestBody = z.object({
   description: z.string().optional(),
   deadline: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
   startDate: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
   endDate: z
     .string()
-    .refine((val) => !isNaN(Date.parse(val)), {
-      message: 'Invalid date format, should be in ISO 8601 format',
-    })
+    .datetime({ message: 'Invalid date format, should be in ISO 8601 format' })
     .optional(),
 })
 
 export const CreateSemesterRequestBody = z.object({
   name: z.string(),
   description: z.string().optional(),
-  deadline: z.string().refine((val) => !isNaN(Date.parse(val)), {
-    message: 'Invalid date format, should be in ISO 8601 format',
-  }),
-  startDate: z.string().refine((val) => !isNaN(Date.parse(val)), {
-    message: 'Invalid date format, should be in ISO 8601 format',
-  }),
-  endDate: z.string().refine((val) => !isNaN(Date.parse(val)), {
-    message: 'Invalid date format, should be in ISO 8601 format',
-  }),
+  deadline: z.string().datetime({ message: 'Invalid date format, should be in ISO 8601 format' }),
+  startDate: z.string().datetime({ message: 'Invalid date format, should be in ISO 8601 format' }),
+  endDate: z.string().datetime({ message: 'Invalid date format, should be in ISO 8601 format' }),
 })


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

**Changes:**

- Replaced custom date refinement logic with zod's built-in datetime method for cleaner and more concise validation.
- Replaced individual clearCollection calls with a loop iterating over payload collections, simplifying and reducing redundancy.

**Fixes** #237 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I have requested a review from another user
