### PR TITLE
247 Add timeframe filtering to semester retrieval

### DIFF
--- a/src/app/api/semesters/route.ts
+++ b/src/app/api/semesters/route.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import SemesterService from '@/data-layer/services/SemesterService'
 import { Security } from '@/business-layer/middleware/Security'
+import { SemesterType } from '@/types/Semester'
 
 class RouteWrapper {
   /**
@@ -16,11 +17,16 @@ class RouteWrapper {
     const searchParams = req.nextUrl.searchParams
     const page = parseInt(searchParams.get('page') || '1')
     const limit = parseInt(searchParams.get('limit') || '100')
+    const timeframe = (searchParams.get('timeframe') || SemesterType.Default) as SemesterType
     if (limit < 0 || limit > 100) {
       return NextResponse.json({ error: 'Invalid page number' }, { status: StatusCodes.NOT_FOUND })
     }
     const semesterService = new SemesterService()
-    const { docs: semester, nextPage } = await semesterService.getAllSemesters(limit, page)
+    const { docs: semester, nextPage } = await semesterService.getAllSemesters(
+      limit,
+      page,
+      timeframe,
+    )
     return NextResponse.json({ data: semester, nextPage })
   }
 }

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -30,32 +30,34 @@ describe('Semester service tests', () => {
   })
 
   it('should get all semesters with timeframe filtering', async () => {
-    const semester1 = await semesterService.createSemester({
+    const pastSemester = await semesterService.createSemester({
       ...semesterCreateMock,
       startDate: new Date('2023-01-01').toISOString(),
       endDate: new Date('2023-06-30').toISOString(),
     })
+
     const today = new Date()
-    const semester2 = await semesterService.createSemester({
+
+    const upcomingSemester = await semesterService.createSemester({
       ...semesterCreateMock,
       startDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
       endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
-    const semester3 = await semesterService.createSemester({
+    const currentSemester = await semesterService.createSemester({
       ...semesterCreateMock,
       startDate: new Date(today.getFullYear() - 1, today.getMonth(), today.getDate()).toISOString(),
       endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
+    const past = await semesterService.getAllSemesters(100, 1, SemesterType.Past)
+    expect(past.docs).toStrictEqual([pastSemester])
+
     const current = await semesterService.getAllSemesters(100, 1, SemesterType.Current)
-    expect(current.docs).toStrictEqual([semester3])
+    expect(current.docs).toStrictEqual([currentSemester])
 
     const upcoming = await semesterService.getAllSemesters(100, 1, SemesterType.Upcoming)
-    expect(upcoming.docs).toStrictEqual([semester2])
-
-    const past = await semesterService.getAllSemesters(100, 1, SemesterType.Past)
-    expect(past.docs).toStrictEqual([semester1])
+    expect(upcoming.docs).toStrictEqual([upcomingSemester])
   })
 
   it('should return undefined if semester does not exist', async () => {

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -1,6 +1,7 @@
 import { testPayloadObject } from '@/test-config/utils'
 import SemesterService from './SemesterService'
 import { semesterCreateMock, semesterCreateMock2 } from '@/test-config/mocks/Semester.mock'
+import { SemesterType } from '@/types/Semester'
 
 describe('Semester service tests', () => {
   const semesterService = new SemesterService()
@@ -26,6 +27,35 @@ describe('Semester service tests', () => {
     const fetchedSemester = await semesterService.getAllSemesters()
     expect(fetchedSemester.docs.length).toEqual(2)
     expect(fetchedSemester.docs).toEqual(expect.arrayContaining([semester1, semester2]))
+  })
+
+  it('should get all semesters with timeframe filtering', async () => {
+    const semester1 = await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date('2023-01-01').toISOString(),
+      endDate: new Date('2023-06-30').toISOString(),
+    })
+    const today = new Date()
+    const semester2 = await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
+      endDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
+    })
+
+    const semester3 = await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear()-1, today.getMonth(), today.getDay()).toISOString(),
+      endDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
+    })
+
+    const current = await semesterService.getAllSemesters(100, 1, SemesterType.Current)
+    expect(current.docs).toStrictEqual([semester3])
+
+    const upcoming = await semesterService.getAllSemesters(100, 1, SemesterType.Upcoming)
+    expect(upcoming.docs).toStrictEqual([semester2])
+
+    const past = await semesterService.getAllSemesters(100, 1, SemesterType.Past)
+    expect(past.docs).toStrictEqual([semester1])
   })
 
   it('should return undefined if semester does not exist', async () => {

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -38,14 +38,14 @@ describe('Semester service tests', () => {
     const today = new Date()
     const semester2 = await semesterService.createSemester({
       ...semesterCreateMock,
-      startDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
-      endDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
+      startDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
+      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
     const semester3 = await semesterService.createSemester({
       ...semesterCreateMock,
-      startDate: new Date(today.getFullYear()-1, today.getMonth(), today.getDay()).toISOString(),
-      endDate: new Date(today.getFullYear()+1, today.getMonth(), today.getDay()).toISOString(),
+      startDate: new Date(today.getFullYear() - 1, today.getMonth(), today.getDate()).toISOString(),
+      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
     const current = await semesterService.getAllSemesters(100, 1, SemesterType.Current)

--- a/src/types/Semester.ts
+++ b/src/types/Semester.ts
@@ -1,0 +1,6 @@
+export enum SemesterType {
+  Upcoming = 'upcoming',
+  Current = 'current',
+  Past = 'past',
+  Default = 'default',
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Introduced `SemesterType` enum for timeframe filtering.
- Updated `getAllSemesters` to support filtering by current, past, or upcoming semesters.
- Added tests to validate timeframe filtering functionality.

**Fixes** #247 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
