### PR TITLE
257 Create endpoint to fetch current semester

### DIFF
--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -86,7 +86,7 @@ describe('Semester service tests', () => {
       endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
-    const nextSem = await semesterService.getAllSemesters(100, 1, SemesterType.NextSemester)
+    const nextSem = await semesterService.getAllSemesters(100, 1, SemesterType.Next)
     expect(nextSem.docs).toStrictEqual([nextSemester])
   })
 

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -65,25 +65,27 @@ describe('Semester service tests', () => {
 
     await semesterService.createSemester({
       ...semesterCreateMock,
-      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
-      endDate: new Date(
-        today.getFullYear() + 1,
-        today.getMonth(),
-        today.getDate() + 1,
-      ).toISOString(),
-    })
-
-    // Supposedly this semester is fetched as it is a 1 day difference
-    const nextSemester = await semesterService.createSemester({
-      ...semesterCreateMock,
-      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
-      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2).toISOString(),
+      endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 3).toISOString(),
     })
 
     await semesterService.createSemester({
       ...semesterCreateMock,
-      startDate: new Date(today.getFullYear(), today.getMonth() + 7, today.getDate()).toISOString(),
-      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 3).toISOString(),
+      endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 4).toISOString(),
+    })
+
+    // Supposedly this semester is fetched as it is the closest in start date and end date
+    const nextSemester = await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
+      endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2).toISOString(),
+    })
+
+    await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
+      endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 3).toISOString(),
     })
 
     const nextSem = await semesterService.getAllSemesters(100, 1, SemesterType.Next)

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -63,6 +63,17 @@ describe('Semester service tests', () => {
   it('should get the next upcoming semester', async () => {
     const today = new Date()
 
+    await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
+      endDate: new Date(
+        today.getFullYear() + 1,
+        today.getMonth(),
+        today.getDate() + 1,
+      ).toISOString(),
+    })
+
+    // Supposedly this semester is fetched as it is a 1 day difference
     const nextSemester = await semesterService.createSemester({
       ...semesterCreateMock,
       startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -63,9 +63,9 @@ describe('Semester service tests', () => {
   it('should get the next upcoming semester', async () => {
     const today = new Date()
 
-    const upcomingSemester = await semesterService.createSemester({
+    const nextSemester = await semesterService.createSemester({
       ...semesterCreateMock,
-      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate()+1).toISOString(),
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1).toISOString(),
       endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
@@ -75,8 +75,8 @@ describe('Semester service tests', () => {
       endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
     })
 
-    const past = await semesterService.getAllSemesters(100, 1, SemesterType.NextSemester)
-    expect(past.docs).toStrictEqual([upcomingSemester])
+    const nextSem = await semesterService.getAllSemesters(100, 1, SemesterType.NextSemester)
+    expect(nextSem.docs).toStrictEqual([nextSemester])
   })
 
   it('should return undefined if semester does not exist', async () => {

--- a/src/data-layer/services/SemesterService.test.ts
+++ b/src/data-layer/services/SemesterService.test.ts
@@ -60,6 +60,25 @@ describe('Semester service tests', () => {
     expect(upcoming.docs).toStrictEqual([upcomingSemester])
   })
 
+  it('should get the next upcoming semester', async () => {
+    const today = new Date()
+
+    const upcomingSemester = await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate()+1).toISOString(),
+      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
+    })
+
+    await semesterService.createSemester({
+      ...semesterCreateMock,
+      startDate: new Date(today.getFullYear(), today.getMonth() + 7, today.getDate()).toISOString(),
+      endDate: new Date(today.getFullYear() + 1, today.getMonth(), today.getDate()).toISOString(),
+    })
+
+    const past = await semesterService.getAllSemesters(100, 1, SemesterType.NextSemester)
+    expect(past.docs).toStrictEqual([upcomingSemester])
+  })
+
   it('should return undefined if semester does not exist', async () => {
     await expect(semesterService.getSemester('nonexistent_id')).rejects.toThrow('Not Found')
   })

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -41,10 +41,10 @@ export default class SemesterService {
     timeframe: SemesterType = SemesterType.Default,
   ): Promise<PaginatedDocs<Semester>> {
     const currentDate = new Date().toISOString()
-    const nextSemester = new Date()
-    nextSemester.setMonth(nextSemester.getMonth() + 6)
+
     let filter: Where = {}
     let sort: Sort = []
+
     switch (timeframe) {
       case SemesterType.Current:
         filter = {

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -76,7 +76,7 @@ export default class SemesterService {
           },
         }
         limit = 1
-        sort = ['-startDate']
+        sort = ['startDate', 'endDate']
         break
       case SemesterType.Past:
         filter = {

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -41,6 +41,8 @@ export default class SemesterService {
     timeframe: SemesterType = SemesterType.Default,
   ): Promise<PaginatedDocs<Semester>> {
     const currentDate = new Date().toISOString()
+    const nextSemester = new Date()
+    nextSemester.setMonth(nextSemester.getMonth() + 6)
     let filter: Where = {}
     switch (timeframe) {
       case SemesterType.Current:
@@ -64,6 +66,14 @@ export default class SemesterService {
           startDate: {
             greater_than: currentDate,
           },
+        }
+        break
+      case SemesterType.NextSemester:
+        filter = {
+          startDate: {
+            greater_than: currentDate,
+            less_than: nextSemester.toISOString()
+          }
         }
         break
       case SemesterType.Past:

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -75,6 +75,7 @@ export default class SemesterService {
             less_than: nextSemester.toISOString()
           }
         }
+        limit = 1
         break
       case SemesterType.Past:
         filter = {

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -72,8 +72,8 @@ export default class SemesterService {
         filter = {
           startDate: {
             greater_than: currentDate,
-            less_than: nextSemester.toISOString()
-          }
+            less_than: nextSemester.toISOString(),
+          },
         }
         limit = 1
         break

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -69,7 +69,7 @@ export default class SemesterService {
           },
         }
         break
-      case SemesterType.NextSemester:
+      case SemesterType.Next:
         filter = {
           startDate: {
             greater_than: currentDate,

--- a/src/data-layer/services/SemesterService.ts
+++ b/src/data-layer/services/SemesterService.ts
@@ -1,7 +1,7 @@
 import { CreateSemesterData, UpdateSemesterData } from '@/types/Collections'
 import { payload } from '../adapters/Payload'
 import { Semester } from '@/payload-types'
-import { PaginatedDocs, Where } from 'payload'
+import { PaginatedDocs, Sort, Where } from 'payload'
 import { SemesterType } from '@/types/Semester'
 
 export default class SemesterService {
@@ -44,6 +44,7 @@ export default class SemesterService {
     const nextSemester = new Date()
     nextSemester.setMonth(nextSemester.getMonth() + 6)
     let filter: Where = {}
+    let sort: Sort = []
     switch (timeframe) {
       case SemesterType.Current:
         filter = {
@@ -72,10 +73,10 @@ export default class SemesterService {
         filter = {
           startDate: {
             greater_than: currentDate,
-            less_than: nextSemester.toISOString(),
           },
         }
         limit = 1
+        sort = ['-startDate']
         break
       case SemesterType.Past:
         filter = {
@@ -93,6 +94,7 @@ export default class SemesterService {
       pagination: true,
       page: page,
       where: filter,
+      sort,
     })
     return data
   }

--- a/src/types/Semester.ts
+++ b/src/types/Semester.ts
@@ -1,6 +1,6 @@
 export enum SemesterType {
   Upcoming = 'upcoming',
-  NextSemester = 'next',
+  Next = 'next',
   Current = 'current',
   Past = 'past',
   Default = 'default',

--- a/src/types/Semester.ts
+++ b/src/types/Semester.ts
@@ -1,5 +1,6 @@
 export enum SemesterType {
   Upcoming = 'upcoming',
+  NextSemester = 'next',
   Current = 'current',
   Past = 'past',
   Default = 'default',


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Introduced a new `SemesterType.NextSemester` enum value.
- Added logic in `getAllSemesters` to filter semesters starting within the next 6 months.
- Created a test case to validate fetching the next upcoming semester.
- Set limit to 1 for next semester query
- Sorts so that the semester must be the earliest available semester

**Fixes** #257 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
