### PR TITLE
265 Fix redirection after login

### DIFF
--- a/src/app/api/auth/google/callback/route.test.ts
+++ b/src/app/api/auth/google/callback/route.test.ts
@@ -123,7 +123,7 @@ describe('GET /api/auth/google/callback', () => {
 
     await callback(req)
     expect(redirect).toHaveBeenCalled()
-    expect(redirect).toHaveBeenCalledWith('/')
+    expect(redirect).toHaveBeenCalledWith('/client')
   })
 
   it('returns 400 if state does not match', async () => {

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -75,6 +75,8 @@ export const GET = async (req: NextRequest) => {
   const fetchedAuth = await authService.getAuthByEmail(email)
   if (fetchedAuth) {
     await authService.updateAuth(fetchedAuth.id, {
+      provider: 'google',
+      providerAccountId: sub,
       accessToken: tokens.access_token,
       expiresAt: tokens.expiry_date,
       scope: scopes.join(' '),
@@ -83,7 +85,6 @@ export const GET = async (req: NextRequest) => {
   } else {
     await authService.createAuth({
       email,
-      type: 'oauth',
       provider: 'google',
       providerAccountId: sub,
       accessToken: tokens.access_token,
@@ -103,5 +104,14 @@ export const GET = async (req: NextRequest) => {
     maxAge: 60 * 60,
   })
 
-  return redirect('/')
+  switch (user.role) {
+    case UserRole.Admin:
+      return redirect('/admin')
+    case UserRole.Client:
+      return redirect('/client')
+    case UserRole.Student:
+      return redirect('/student')
+    default:
+      return redirect('/')
+  }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,13 +1,15 @@
 import { StatusCodes } from 'http-status-codes'
 import { NextRequest, NextResponse } from 'next/server'
+import { redirect } from 'next/navigation'
 import { z, ZodError } from 'zod'
+import { NotFound } from 'payload'
 
 import AuthDataService from '@/data-layer/services/AuthService'
 import AuthService from '@/business-layer/services/AuthService'
-import { NotFound } from 'payload'
 import UserService from '@/data-layer/services/UserService'
 import { cookies } from 'next/headers'
 import { AUTH_COOKIE_NAME } from '@/types/Auth'
+import { UserRole } from '@/types/User'
 
 export const LoginRequestBodySchema = z.object({
   email: z.string().email(),
@@ -42,7 +44,16 @@ export const POST = async (req: NextRequest) => {
       maxAge: 60 * 60,
     })
 
-    return NextResponse.json({ message: 'Login successful' }, { status: StatusCodes.OK })
+    switch (user.role) {
+      case UserRole.Admin:
+        return redirect('/admin')
+      case UserRole.Client:
+        return redirect('/client')
+      case UserRole.Student:
+        return redirect('/student')
+      default:
+        return redirect('/')
+    }
   } catch (error) {
     if (error instanceof ZodError) {
       return NextResponse.json(

--- a/src/app/api/auth/register/route.test.ts
+++ b/src/app/api/auth/register/route.test.ts
@@ -33,7 +33,6 @@ describe('tests /api/auth/register', () => {
 
     const auth = await authService.getAuthByEmail(body.email)
     expect(auth.password).not.toEqual(body.password)
-    expect(auth.type).toEqual('password')
   })
 
   it('should return a 409 conflict if user already exists', async () => {

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -41,7 +41,6 @@ export const POST = async (req: NextRequest) => {
     await authDataService.createAuth({
       email: body.email,
       password: hash,
-      type: 'password',
     })
 
     return NextResponse.json(

--- a/src/data-layer/collections/Authentication.ts
+++ b/src/data-layer/collections/Authentication.ts
@@ -1,7 +1,5 @@
 import { CollectionConfig } from 'payload'
 
-import { AuthType } from '@/types/Auth'
-
 export const Authentication: CollectionConfig = {
   slug: 'authentication',
   access: {},
@@ -20,15 +18,6 @@ export const Authentication: CollectionConfig = {
       required: false,
       admin: {
         description: 'The hashed user password',
-      },
-    },
-    {
-      name: 'type',
-      type: 'select',
-      options: Object.values(AuthType),
-      required: true,
-      admin: {
-        description: 'The type of authentication',
       },
     },
     {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -165,10 +165,6 @@ export interface Authentication {
   /**
    * The type of authentication
    */
-  type: 'oauth' | 'password';
-  /**
-   * The type of authentication
-   */
   provider?: 'google' | null;
   /**
    * The provider account id of the user authentication
@@ -449,7 +445,6 @@ export interface AdminSelect<T extends boolean = true> {
 export interface AuthenticationSelect<T extends boolean = true> {
   email?: T;
   password?: T;
-  type?: T;
   provider?: T;
   providerAccountId?: T;
   refreshToken?: T;

--- a/src/test-config/mocks/Auth.mock.ts
+++ b/src/test-config/mocks/Auth.mock.ts
@@ -1,5 +1,5 @@
 import { Authentication, User } from '@/payload-types'
-import { AuthType, UserInfoResponse } from '@/types/Auth'
+import { UserInfoResponse } from '@/types/Auth'
 import { CreateAuthenticationData } from '@/types/Collections'
 import { UserRole } from '@/types/User'
 
@@ -40,7 +40,6 @@ export const googleUserResponseMock: UserInfoResponse = {
 export const authMock: Authentication = {
   id: '67ff38a56a35e1b6cf43a681',
   email: 'jeffery@gmail.com',
-  type: AuthType.OAUTH,
   provider: 'google',
   providerAccountId: '1234567890',
   refreshToken: 'refreshToken',
@@ -52,7 +51,6 @@ export const authMock: Authentication = {
 
 export const authCreateMock: CreateAuthenticationData = {
   email: 'jeffery@gmail.com',
-  type: AuthType.OAUTH,
   provider: 'google',
   providerAccountId: 'account_id',
   refreshToken: 'refreshToken',

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,10 +1,5 @@
 import z from 'zod'
 
-export enum AuthType {
-  OAUTH = 'oauth',
-  PASSWORD = 'password',
-}
-
 export const AUTH_COOKIE_NAME = 'auth_token'
 
 export const SALT_ROUNDS = 10


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

> [!NOTE]
> This indicates that users can use both forms of authentication (google and standard email/password)

- Redirect users based on role after login and Google callback
- Add `provider` and `providerAccountId` updates in auth service
- Remove `type` field from authentication schema and related code

**Fixes** #265 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
