### PR TITLE
305 Create endpoint to fetch a projects related semesters

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react'
-import '../src/app/globals.css'
+import '../src/app/(frontend)/globals.css'
 
 const preview: Preview = {
   parameters: {

--- a/src/app/api/admin/export/semesters/[id]/route.ts
+++ b/src/app/api/admin/export/semesters/[id]/route.ts
@@ -18,11 +18,11 @@ class RouteWrapper {
     const { id } = await params
     const projectService = new ProjectService()
     try {
-      let projects = await projectService.getAllProjectsBySemester(id)
+      let projects = await projectService.getAllSemesterProjectsBySemester(id)
       const allSemesterProjects: SemesterProjectType[] = [...projects.docs]
       while (projects.nextPage) {
         allSemesterProjects.push(...projects.docs)
-        projects = await projectService.getAllProjectsBySemester(id, 100, projects.nextPage)
+        projects = await projectService.getAllSemesterProjectsBySemester(id, 100, projects.nextPage)
       }
       const csvHeaders = [
         'id',

--- a/src/app/api/projects/[id]/semesters/route.test.ts
+++ b/src/app/api/projects/[id]/semesters/route.test.ts
@@ -6,7 +6,7 @@ import ProjectService from '@/data-layer/services/ProjectService'
 import SemesterService from '@/data-layer/services/SemesterService'
 import { adminToken, clientToken, studentToken } from '@/test-config/routes-setup'
 import { AUTH_COOKIE_NAME } from '@/types/Auth'
-import { GET } from './route'
+import { GET, GetProjectSemestersResponse } from './route'
 import { projectCreateMock, semesterProjectCreateMock } from '@/test-config/mocks/Project.mock'
 import { semesterCreateMock } from '@/test-config/mocks/Semester.mock'
 
@@ -20,7 +20,7 @@ describe('/api/projects/[id]/semesters', async () => {
       cookieStore.set(AUTH_COOKIE_NAME, studentToken)
       const res = await GET(createMockNextRequest(''), { params: paramsToPromise({ id: 'a' }) })
       expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
-      expect((await res.json()).error).toBe('No scope')
+      expect(((await res.json()) as GetProjectSemestersResponse).error).toBe('No scope')
     })
 
     it("should return a 401 if the requesting user isn't associated to the project", async () => {
@@ -33,7 +33,7 @@ describe('/api/projects/[id]/semesters', async () => {
       })
 
       expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
-      expect((await res.json()).error).toBe(
+      expect(((await res.json()) as GetProjectSemestersResponse).error).toBe(
         'This project is not associated with the requesting client',
       )
     })
@@ -58,7 +58,7 @@ describe('/api/projects/[id]/semesters', async () => {
         params: paramsToPromise({ id: project.id }),
       })
 
-      const json = await res.json()
+      const json: GetProjectSemestersResponse = await res.json()
       expect(json.data.length).toStrictEqual(2)
       expect(json.data).toStrictEqual(expect.arrayContaining([semester, semester2]))
     })

--- a/src/app/api/projects/[id]/semesters/route.test.ts
+++ b/src/app/api/projects/[id]/semesters/route.test.ts
@@ -1,0 +1,66 @@
+import { cookies } from 'next/headers'
+import { StatusCodes } from 'http-status-codes'
+
+import { createMockNextRequest, paramsToPromise } from '@/test-config/utils'
+import ProjectService from '@/data-layer/services/ProjectService'
+import SemesterService from '@/data-layer/services/SemesterService'
+import { adminToken, clientToken, studentToken } from '@/test-config/routes-setup'
+import { AUTH_COOKIE_NAME } from '@/types/Auth'
+import { GET } from './route'
+import { projectCreateMock, semesterProjectCreateMock } from '@/test-config/mocks/Project.mock'
+import { semesterCreateMock } from '@/test-config/mocks/Semester.mock'
+
+describe('/api/projects/[id]/semesters', async () => {
+  const cookieStore = await cookies()
+  const semesterService = new SemesterService()
+  const projectService = new ProjectService()
+
+  describe('GET', () => {
+    it('should return a 401 if the requesting user is a student', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, studentToken)
+      const res = await GET(createMockNextRequest(''), { params: paramsToPromise({ id: 'a' }) })
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect((await res.json()).error).toBe('No scope')
+    })
+
+    it("should return a 401 if the requesting user isn't associated to the project", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, clientToken)
+      const project = await projectService.createProject(projectCreateMock)
+      await projectService.createSemesterProject(semesterProjectCreateMock)
+
+      const res = await GET(createMockNextRequest(''), {
+        params: paramsToPromise({ id: project.id }),
+      })
+
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect((await res.json()).error).toBe(
+        'This project is not associated with the requesting client',
+      )
+    })
+
+    it('should return all the semesters that are releated to a project', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+      const semester = await semesterService.createSemester(semesterCreateMock)
+      const semester2 = await semesterService.createSemester(semesterCreateMock)
+      const project = await projectService.createProject(projectCreateMock)
+      await projectService.createSemesterProject({
+        ...semesterProjectCreateMock,
+        semester,
+        project,
+      })
+      await projectService.createSemesterProject({
+        ...semesterProjectCreateMock,
+        semester: semester2,
+        project,
+      })
+
+      const res = await GET(createMockNextRequest(''), {
+        params: paramsToPromise({ id: project.id }),
+      })
+
+      const json = await res.json()
+      expect(json.data.length).toStrictEqual(2)
+      expect(json.data).toStrictEqual(expect.arrayContaining([semester, semester2]))
+    })
+  })
+})

--- a/src/app/api/projects/[id]/semesters/route.ts
+++ b/src/app/api/projects/[id]/semesters/route.ts
@@ -34,13 +34,16 @@ class RouteWrapper {
       }
 
       const semesterProjects = await projectService.getSemesterProjectsByProject(project.id)
-      const semesters: Set<Semester> = new Set()
+      const semestersMap: Map<string, Semester> = new Map()
       semesterProjects.forEach((semesterProject: SemesterProject) => {
-        semesters.add(semesterProject.semester as Semester)
+        const semester = semesterProject.semester as Semester
+        if (semester && semester.id) {
+          semestersMap.set(semester.id, semester)
+        }
       })
 
       return NextResponse.json({
-        data: [...semesters],
+        data: Array.from(semestersMap.values()),
       })
     } catch (error) {
       if (error instanceof NotFound) {

--- a/src/app/api/projects/[id]/semesters/route.ts
+++ b/src/app/api/projects/[id]/semesters/route.ts
@@ -32,11 +32,13 @@ class RouteWrapper {
           { status: StatusCodes.UNAUTHORIZED },
         )
       }
+
       const semesterProjects = await projectService.getSemesterProjectsByProject(project.id)
       const semesters: Set<Semester> = new Set()
       semesterProjects.forEach((semesterProject: SemesterProject) => {
         semesters.add(semesterProject.semester as Semester)
       })
+
       return NextResponse.json({
         data: [...semesters],
       })

--- a/src/app/api/projects/[id]/semesters/route.ts
+++ b/src/app/api/projects/[id]/semesters/route.ts
@@ -1,0 +1,54 @@
+import { StatusCodes } from 'http-status-codes'
+import { NextResponse } from 'next/server'
+import { NotFound } from 'payload'
+
+import ProjectService from '@/data-layer/services/ProjectService'
+import { Semester, SemesterProject } from '@/payload-types'
+import { Security } from '@/business-layer/middleware/Security'
+import { RequestWithUser } from '@/types/Requests'
+import { UserRole } from '@/types/User'
+
+class RouteWrapper {
+  @Security('jwt', ['admin', 'client'])
+  static async GET(
+    req: RequestWithUser,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>
+    },
+  ) {
+    const { id } = await params
+    const projectService = new ProjectService()
+    try {
+      const project = await projectService.getProjectById(id)
+      if (
+        req.user.role !== UserRole.Admin &&
+        project.client !== req.user.id &&
+        !project.additionalClients?.includes(req.user.id)
+      ) {
+        return NextResponse.json(
+          { error: 'This project is not associated with the requesting client' },
+          { status: StatusCodes.UNAUTHORIZED },
+        )
+      }
+      const semesterProjects = await projectService.getSemesterProjectsByProject(project.id)
+      const semesters: Set<Semester> = new Set()
+      semesterProjects.forEach((semesterProject: SemesterProject) => {
+        semesters.add(semesterProject.semester as Semester)
+      })
+      return NextResponse.json({
+        data: [...semesters],
+      })
+    } catch (error) {
+      if (error instanceof NotFound) {
+        return NextResponse.json({ error: 'Project not found' }, { status: StatusCodes.NOT_FOUND })
+      }
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: StatusCodes.INTERNAL_SERVER_ERROR },
+      )
+    }
+  }
+}
+export const GET = RouteWrapper.GET

--- a/src/app/api/semesters/[id]/projects/route.ts
+++ b/src/app/api/semesters/[id]/projects/route.ts
@@ -59,17 +59,27 @@ class RouterWrapper {
     let docs: SemesterProject[], nextPage: number | null | undefined
 
     if (req.user.role === UserRole.Student) {
-      const paginatedProjects = await projectService.getAllProjectsBySemester(id, limit, page, {
-        published: true,
-        status: status ? (status as ProjectStatus) : undefined,
-      })
+      const paginatedProjects = await projectService.getAllSemesterProjectsBySemester(
+        id,
+        limit,
+        page,
+        {
+          published: true,
+          status: status ? (status as ProjectStatus) : undefined,
+        },
+      )
       docs = paginatedProjects.docs
       nextPage = paginatedProjects.nextPage
     } else {
-      const paginatedProjects = await projectService.getAllProjectsBySemester(id, limit, page, {
-        published: !!published ? JSON.parse(published) : undefined,
-        status: status ? (status as ProjectStatus) : undefined,
-      })
+      const paginatedProjects = await projectService.getAllSemesterProjectsBySemester(
+        id,
+        limit,
+        page,
+        {
+          published: !!published ? JSON.parse(published) : undefined,
+          status: status ? (status as ProjectStatus) : undefined,
+        },
+      )
       docs = paginatedProjects.docs
       nextPage = paginatedProjects.nextPage
     }

--- a/src/data-layer/services/ProjectService.test.ts
+++ b/src/data-layer/services/ProjectService.test.ts
@@ -205,20 +205,20 @@ describe('Project service methods test', () => {
       ...semesterProjectCreateMock,
       semester: semester1.id,
     })
-    const res = await projectService.getAllProjectsBySemester(semester1.id)
+    const res = await projectService.getAllSemesterProjectsBySemester(semester1.id)
     expect(res.docs.length).toEqual(3)
     expect(res.nextPage).toBeNull()
-    const res2 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1)
+    const res2 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1)
     expect(res2.docs.length).toEqual(2)
     expect(res2.hasNextPage).toBe(true)
-    const res3 = await projectService.getAllProjectsBySemester(semester1.id, 2, 2)
+    const res3 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 2)
     expect(res3.docs.length).toEqual(1)
     expect(res3.hasNextPage).toBe(false)
   })
 
   it('Should return nothing if no projects for a semester', async () => {
     const semester1 = await semesterService.createSemester(semesterCreateMock)
-    const res = await projectService.getAllProjectsBySemester(semester1.id)
+    const res = await projectService.getAllSemesterProjectsBySemester(semester1.id)
     expect(res.docs.length).toEqual(0)
     expect(res.nextPage).toBeNull()
   })
@@ -245,17 +245,17 @@ describe('Project service methods test', () => {
       published: true,
     })
 
-    const res = await projectService.getAllProjectsBySemester(semester1.id, 100, 1, {
+    const res = await projectService.getAllSemesterProjectsBySemester(semester1.id, 100, 1, {
       published: true,
     })
     expect(res.docs.length).toEqual(1)
     expect(res.nextPage).toBeNull()
-    const res2 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1, {
+    const res2 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1, {
       published: true,
     })
     expect(res2.docs.length).toEqual(1)
     expect(res2.nextPage).toBe(null)
-    const res3 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1, {
+    const res3 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1, {
       published: false,
     })
     expect(res3.docs.length).toEqual(2)
@@ -284,17 +284,17 @@ describe('Project service methods test', () => {
       status: ProjectStatus.Accepted,
     })
 
-    const res = await projectService.getAllProjectsBySemester(semester1.id, 100, 1, {
+    const res = await projectService.getAllSemesterProjectsBySemester(semester1.id, 100, 1, {
       status: ProjectStatus.Accepted,
     })
     expect(res.docs.length).toEqual(1)
     expect(res.nextPage).toBeNull()
-    const res2 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1, {
+    const res2 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1, {
       status: ProjectStatus.Accepted,
     })
     expect(res2.docs.length).toEqual(1)
     expect(res2.nextPage).toBeNull()
-    const res3 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1, {
+    const res3 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1, {
       status: ProjectStatus.Rejected,
     })
     expect(res3.docs.length).toEqual(1)
@@ -326,17 +326,30 @@ describe('Project service methods test', () => {
       published: true,
     })
 
-    const res = await projectService.getAllProjectsBySemester(semester1.id, 100, 1, {
+    const res = await projectService.getAllSemesterProjectsBySemester(semester1.id, 100, 1, {
       published: true,
       status: ProjectStatus.Accepted,
     })
     expect(res.docs.length).toEqual(1)
     expect(res.nextPage).toBeNull()
-    const res2 = await projectService.getAllProjectsBySemester(semester1.id, 2, 1, {
+
+    const res2 = await projectService.getAllSemesterProjectsBySemester(semester1.id, 2, 1, {
       published: false,
       status: ProjectStatus.Rejected,
     })
     expect(res2.docs.length).toEqual(1)
     expect(res2.nextPage).toBeNull()
+  })
+
+  it('should get all semester projects by project ID', async () => {
+    expect(await projectService.getSemesterProjectsByProject('spirit_blossom_yone')).toEqual([])
+
+    const project = await projectService.createProject(projectCreateMock)
+    const semesterProject = await projectService.createSemesterProject({
+      ...semesterProjectCreateMock,
+      project,
+    })
+    await projectService.createSemesterProject(semesterProjectCreateMock)
+    expect(await projectService.getSemesterProjectsByProject(project.id)).toEqual([semesterProject])
   })
 })

--- a/src/data-layer/services/ProjectService.ts
+++ b/src/data-layer/services/ProjectService.ts
@@ -156,6 +156,10 @@ export default class ProjectService {
     })
   }
 
+  /*
+   * Semester Project Methods
+   */
+
   /**
    * Creates a new semesterProject
    *
@@ -200,7 +204,7 @@ export default class ProjectService {
   }
 
   /**
-   * Retrieves all projects by semester
+   * Retrieves all semester projects by semester
    *
    * @param id The ID the the semester
    * @param limit The limit of projects to fetch
@@ -208,7 +212,7 @@ export default class ProjectService {
    * @param options Additional filtering params such as published or project status
    * @returns The paginated semester projects
    */
-  public async getAllProjectsBySemester(
+  public async getAllSemesterProjectsBySemester(
     id: string,
     limit: number = 100,
     page: number = 1,
@@ -217,7 +221,7 @@ export default class ProjectService {
       status?: ProjectStatus
     },
   ): Promise<PaginatedDocs<SemesterProject>> {
-    const semesterProjects = await payload.find({
+    return await payload.find({
       collection: 'semesterProject',
       limit,
       pagination: true,
@@ -228,7 +232,26 @@ export default class ProjectService {
         ...(!!options?.status ? { status: { equals: options.status } } : {}),
       },
     })
-    return semesterProjects
+  }
+
+  /**
+   * Method used to retrieve all {@link SemesterProject}'s that are related to a certain {@link Project}
+   *
+   * @param id The ID of the {@link Project} that's related to the {@link SemesterProject}'s returned
+   * @returns A list of semester projects
+   */
+  public async getSemesterProjectsByProject(id: string): Promise<SemesterProject[]> {
+    return (
+      await payload.find({
+        collection: 'semesterProject',
+        pagination: false,
+        where: {
+          project: {
+            equals: id,
+          },
+        },
+      })
+    ).docs
   }
 
   /**

--- a/src/types/response-models/CommonResponse.ts
+++ b/src/types/response-models/CommonResponse.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod'
 
 export const CommonResponse = z.object({
+  /**
+   * Any possible error that the response gives
+   * @example No scope
+   */
   error: z.string().optional(),
+  /**
+   * Any non-error informational message by the route
+   * @example Account created
+   */
   message: z.string().optional(),
 })


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Created route under `GET /api/projects/[id]/semesters` to fetch semesters related to a certain project
- Renamed `getAllProjectsBySemester` to `getAllSemesterProjectsBySemester`
- Added `getSemesterProjectsByProject` method to fetch semester projects by project ID
- Updated related API routes and tests to use the new method names

**Fixes** #305 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
