### PR TITLE
307 Allow for uncreated users to have their authentication linked

### DIFF
--- a/src/app/api/auth/google/callback/route.test.ts
+++ b/src/app/api/auth/google/callback/route.test.ts
@@ -3,63 +3,14 @@ import * as nextHeaders from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import {
-  authMock,
-  clientMock,
   CODE_MOCK,
   googleUserResponseMock,
   JWT_MOCK,
-  JWT_SECRET_MOCK,
-  SCOPES_ARRAY_MOCK,
   SCOPES_MOCK,
   STATE_MOCK,
-  tokensMock,
 } from '@/test-config/mocks/Auth.mock'
 import { createMockNextRequest } from '@/test-config/utils'
 import { AUTH_COOKIE_NAME } from '@/types/Auth'
-
-vi.mock('@/business-layer/security/google', async () => {
-  const actual = await vi.importActual<typeof import('@/business-layer/security/google')>(
-    '@/business-layer/security/google',
-  )
-  return {
-    ...actual,
-    googleAuthScopes: SCOPES_ARRAY_MOCK,
-    oauth2Client: {
-      getToken: (code: string) => (code === CODE_MOCK ? { tokens: tokensMock } : null),
-    },
-  }
-})
-
-vi.mock('@/data-layer/services/UserService', () => {
-  return {
-    default: class {
-      getUserByEmail = vi.fn().mockResolvedValue(clientMock)
-      createUser = vi.fn().mockResolvedValue(clientMock)
-    },
-  }
-})
-
-vi.mock('@/data-layer/services/AuthService', () => {
-  return {
-    default: class {
-      createAuth = vi.fn().mockResolvedValue(authMock)
-      getAuthByEmail = vi.fn().mockResolvedValue(authMock)
-      updateAuth = vi.fn().mockResolvedValue(authMock)
-    },
-  }
-})
-
-vi.mock('@/business-layer/services/AuthService', () => {
-  return {
-    default: class {
-      generateJWT = vi.fn().mockReturnValue(JWT_MOCK)
-    },
-  }
-})
-
-vi.mock('next/navigation', () => ({
-  redirect: vi.fn(),
-}))
 
 import { GET as callback } from '@/app/api/auth/google/callback/route'
 
@@ -72,6 +23,7 @@ describe('GET /api/auth/google/callback', () => {
         ? { json: () => googleUserResponseMock }
         : null,
     )
+
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       json: vi.fn().mockResolvedValue(googleUserResponseMock),
     } as unknown as Response)
@@ -84,6 +36,10 @@ describe('GET /api/auth/google/callback', () => {
       }),
     }))
 
+    vi.mock('next/navigation', () => ({
+      redirect: vi.fn(),
+    }))
+
     const mockCookieStore = {
       get: (key: string) => ({ value: key === 'state' ? STATE_MOCK : undefined }),
       set: mockSet,
@@ -93,8 +49,6 @@ describe('GET /api/auth/google/callback', () => {
     vi.spyOn(nextHeaders, 'cookies').mockResolvedValue(
       mockCookieStore as unknown as ReadonlyRequestCookies,
     )
-
-    process.env.JWT_SECRET = JWT_SECRET_MOCK
   })
 
   afterEach(() => vi.restoreAllMocks())
@@ -115,7 +69,7 @@ describe('GET /api/auth/google/callback', () => {
     })
   })
 
-  it('returns JWT token on success auth', async () => {
+  it('should return the correct redirection', async () => {
     const req = createMockNextRequest(
       `/api/auth/google/callback?code=${CODE_MOCK}&state=${STATE_MOCK}&scope=${SCOPES_MOCK}`,
     )

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -61,6 +61,10 @@ export const GET = async (req: NextRequest) => {
   let user: User
   try {
     user = await userService.getUserByEmail(email)
+    await userService.updateUser(user.id, {
+      firstName,
+      lastName: lastName || '',
+    })
   } catch {
     const newUserData: CreateUserData = {
       email,

--- a/src/app/api/auth/register/route.test.ts
+++ b/src/app/api/auth/register/route.test.ts
@@ -35,6 +35,22 @@ describe('tests /api/auth/register', () => {
     expect(auth.password).not.toEqual(body.password)
   })
 
+  it('should use an existing user when signing up', async () => {
+    const body: RegisterRequestBody = {
+      firstName: 'jeffery',
+      lastName: 'ji',
+      email: 'test@example.com',
+      password: 'password123',
+      role: UserRoleWithoutAdmin.Client,
+    }
+    await userService.createUser(body)
+    const allUsersBeforeRegister = (await userService.getAllUsers()).docs
+
+    await POST(createMockNextPostRequest('/api/auth/register', body))
+
+    expect((await userService.getAllUsers()).docs).toStrictEqual(allUsersBeforeRegister)
+  })
+
   it('should return a 409 conflict if user already exists', async () => {
     const body: RegisterRequestBody = {
       firstName: 'jeffery',

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -26,13 +26,15 @@ export const POST = async (req: NextRequest) => {
     const body = RegisterRequestBodySchema.parse(await req.json())
     let user: User
 
+    const auth = await authDataService.getAuthByEmail(body.email)
+    if (auth)
+      return NextResponse.json(
+        { error: 'A user with that email already exists' },
+        { status: StatusCodes.CONFLICT },
+      )
+
     try {
       user = await userService.getUserByEmail(body.email)
-      if (user)
-        return NextResponse.json(
-          { error: 'A user with that email already exists' },
-          { status: StatusCodes.CONFLICT },
-        )
     } catch {
       user = await userService.createUser(body as CreateUserData)
     }

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { StatusCodes } from 'http-status-codes'
 import { NotFound } from 'payload'
 import { z, ZodError } from 'zod'
@@ -7,6 +7,7 @@ import { Security } from '@/business-layer/middleware/Security'
 import { RequestWithUser } from '@/types/Requests'
 import { MediaSchema, UserSchema } from '@/types/Payload'
 import { UserRole } from '@/types/User'
+import { User } from '@/payload-types'
 
 export const UpdateProjectRequestBody = z.object({
   name: z.string().optional(),
@@ -78,11 +79,11 @@ class RouteWrapper {
     const { id } = await params
     const projectService = new ProjectService()
     try {
-      const fetchedProject = await projectService.getProjectById(id)
+      const project = await projectService.getProjectById(id)
       if (
         req.user.role !== UserRole.Admin &&
-        fetchedProject.client !== req.user.id &&
-        !fetchedProject.additionalClients?.includes(req.user.id)
+        (project.client as User).id !== req.user.id &&
+        !(project.additionalClients as User[])?.some((client) => client.id === req.user.id)
       ) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: StatusCodes.UNAUTHORIZED })
       }
@@ -113,11 +114,19 @@ class RouteWrapper {
    * @param params - The parameters object containing the project ID.
    */
   @Security('jwt', ['admin', 'client'])
-  static async DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  static async DELETE(req: RequestWithUser, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params
     const projectService = new ProjectService()
 
     try {
+      const project = await projectService.getProjectById(id)
+      if (
+        req.user.role !== UserRole.Admin &&
+        (project.client as User).id !== req.user.id &&
+        !(project.additionalClients as User[])?.some((client) => client.id === req.user.id)
+      ) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: StatusCodes.UNAUTHORIZED })
+      }
       await projectService.deleteProject(id)
       return new NextResponse(null, { status: StatusCodes.NO_CONTENT })
     } catch (error) {

--- a/src/app/api/projects/[id]/semesters/route.ts
+++ b/src/app/api/projects/[id]/semesters/route.ts
@@ -4,7 +4,7 @@ import { NotFound } from 'payload'
 import { z } from 'zod'
 
 import ProjectService from '@/data-layer/services/ProjectService'
-import { Semester, SemesterProject } from '@/payload-types'
+import { Semester, SemesterProject, User } from '@/payload-types'
 import { Security } from '@/business-layer/middleware/Security'
 import { RequestWithUser } from '@/types/Requests'
 import { UserRole } from '@/types/User'
@@ -31,8 +31,8 @@ class RouteWrapper {
       const project = await projectService.getProjectById(id)
       if (
         req.user.role !== UserRole.Admin &&
-        project.client !== req.user.id &&
-        !project.additionalClients?.includes(req.user.id)
+        (project.client as User).id !== req.user.id &&
+        !(project.additionalClients as User[])?.some((client) => client.id === req.user.id)
       ) {
         return NextResponse.json(
           {

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -7,6 +7,7 @@ import { projectCreateMock, projectCreateMock2 } from '@/test-config/mocks/Proje
 import { GET, POST } from './route'
 import { AUTH_COOKIE_NAME } from '@/types/Auth'
 import { adminToken, clientToken, studentToken } from '@/test-config/routes-setup'
+import { clientMock, studentMock } from '@/test-config/mocks/Auth.mock'
 
 describe('test /api/projects', async () => {
   const projectService = new ProjectService()
@@ -71,6 +72,21 @@ describe('test /api/projects', async () => {
       const data = await res.json()
       expect(data.data.length).toEqual(1)
       expect(data.nextPage).not.toBeNull()
+    })
+
+    it('should only return projects related to the client', async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, clientToken)
+      const relatedProject = await projectService.createProject({
+        ...projectCreateMock,
+        client: studentMock,
+        additionalClients: [clientMock],
+      })
+      await projectService.createProject({ ...projectCreateMock, client: studentMock })
+
+      const res = await GET(createMockNextRequest('http://localhost:3000/api/projects'))
+
+      const json = await res.json()
+      expect(json.data).toStrictEqual([relatedProject])
     })
   })
 

--- a/src/app/api/semesters/[id]/projects/route.ts
+++ b/src/app/api/semesters/[id]/projects/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { StatusCodes } from 'http-status-codes'
 import { z, ZodError } from 'zod'
 import { NotFound } from 'payload'
+
 import ProjectService from '@/data-layer/services/ProjectService'
 import SemesterService from '@/data-layer/services/SemesterService'
 import { ProjectStatus } from '@/types/Project'
@@ -12,18 +13,22 @@ import { UserRole } from '@/types/User'
 import { SemesterProject } from '@/payload-types'
 import { ProjectSchema } from '@/types/Payload'
 
-export const CreateSemesterProjectRequestBody = z.object({
+export const CreateSemesterProjectRequestBodySchema = z.object({
   number: z.number().min(1).nullable().optional(),
   project: z.union([z.string(), ProjectSchema]),
   status: z.nativeEnum(ProjectStatus),
   published: z.boolean(),
 })
+export type CreateSemesterProjectRequestBody = z.infer<
+  typeof CreateSemesterProjectRequestBodySchema
+>
 
 class RouterWrapper {
   /**
    * Fetches all projects for a semester
-   * @param req - The request object.
-   * @param params - The parameters object containing the semester ID.
+   *
+   * @param req The request object.
+   * @param params The parameters object containing the semester ID.
    * @returns A JSON response containing the list of projects and the next page cursor.
    */
   @Security('jwt', ['student', 'admin'])
@@ -89,8 +94,9 @@ class RouterWrapper {
 
   /**
    * Creates a new project for a semester
-   * @param req - The request object.
-   * @param params - The parameters object containing the semester ID.
+   *
+   * @param req The request object.
+   * @param params The parameters object containing the semester ID.
    * @return A JSON response containing the created semester project.
    */
   @Security('jwt', ['admin', 'client'])
@@ -102,7 +108,7 @@ class RouterWrapper {
     try {
       const semester = await semesterService.getSemester(id)
       const bodyData = await req.json()
-      const body = CreateSemesterProjectRequestBody.parse(bodyData)
+      const body = CreateSemesterProjectRequestBodySchema.parse(bodyData)
       try {
         const project = await projectService.getProjectById(
           typeof body.project === 'string' ? body.project : body.project?.id,

--- a/src/data-layer/services/AuthService.ts
+++ b/src/data-layer/services/AuthService.ts
@@ -31,6 +31,7 @@ export default class AuthService {
             equals: email,
           },
         },
+        limit: 1,
       })
     ).docs[0]
   }

--- a/src/data-layer/services/ProjectService.test.ts
+++ b/src/data-layer/services/ProjectService.test.ts
@@ -34,7 +34,7 @@ describe('Project service methods test', () => {
       expect(page2.hasNextPage).toBe(false)
     })
 
-    it('should get all projects with target client ID covering both client and additiona clients', async () => {
+    it('should get all projects with target client ID covering both client and additional clients', async () => {
       await projectService.createProject({
         ...projectCreateMock,
         client: studentMock,

--- a/src/data-layer/services/ProjectService.ts
+++ b/src/data-layer/services/ProjectService.ts
@@ -14,17 +14,39 @@ export default class ProjectService {
    *
    * @param limit The number of projects to return
    * @param page The page number to return
+   * @param options Optional filtering to search for client as well
    * @returns The list of projects
    */
   public async getAllProjects(
     limit: number = 100,
     page: number = 1,
+    options?: {
+      clientId: string
+    },
   ): Promise<PaginatedDocs<Project>> {
     const data = await payload.find({
       collection: 'project',
       limit,
       pagination: true,
       page: page,
+      where: {
+        ...(!!options?.clientId
+          ? {
+              or: [
+                {
+                  client: {
+                    equals: options.clientId,
+                  },
+                },
+                {
+                  additionalClients: {
+                    contains: options.clientId,
+                  },
+                },
+              ],
+            }
+          : {}),
+      },
     })
     return data
   }

--- a/src/test-config/routes-setup.ts
+++ b/src/test-config/routes-setup.ts
@@ -5,9 +5,13 @@ import {
   adminMock,
   CLIENT_JWT_MOCK,
   clientMock,
+  CODE_MOCK,
+  JWT_MOCK,
   JWT_SECRET_MOCK,
+  SCOPES_ARRAY_MOCK,
   STUDENT_JWT_MOCK,
   studentMock,
+  tokensMock,
 } from './mocks/Auth.mock'
 import AuthService from '@/business-layer/services/AuthService'
 import { payload } from '@/data-layer/adapters/Payload'
@@ -34,7 +38,7 @@ beforeEach(async () => {
           if (user === adminMock || user.email === adminMock.email) return ADMIN_JWT_MOCK
           if (user === clientMock || user.email === clientMock.email) return CLIENT_JWT_MOCK
           if (user === studentMock || user.email === studentMock.email) return STUDENT_JWT_MOCK
-          return ''
+          return JWT_MOCK
         })
         decodeJWT = vi.fn().mockImplementation((token) => {
           if (token === ADMIN_JWT_MOCK) return { user: adminMock, accessToken: ACCESS_TOKEN_MOCK }
@@ -43,6 +47,19 @@ beforeEach(async () => {
             return { user: studentMock, accessToken: ACCESS_TOKEN_MOCK }
           return null
         })
+      },
+    }
+  })
+
+  vi.mock('@/business-layer/security/google', async () => {
+    const actual = await vi.importActual<typeof import('@/business-layer/security/google')>(
+      '@/business-layer/security/google',
+    )
+    return {
+      ...actual,
+      googleAuthScopes: SCOPES_ARRAY_MOCK,
+      oauth2Client: {
+        getToken: (code: string) => (code === CODE_MOCK ? { tokens: tokensMock } : null),
       },
     }
   })


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Essentially a massive auth refactor to ensure most routes have the correct coverage.

**Features:**
- Support filtering projects by client ID, including both primary client and additional clients.
- Ensure existing users are reused during registration
- Move duplicate email check to AuthService for consistency
- Add test to verify existing user reuse behavior

**Fixes:**
- Restrict project GET endpoint to client-specific projects
  - Added logic to filter projects by client ID for non-admin users.
  - Updated tests to validate client-specific project filtering.

**Refactors:**
- Simplify mocks in Google callback route tests
- Add user update logic in Google callback handler
- Refactor test setup to include reusable mocks
- Add checks to ensure only associated clients can access or modify projects.
- Update DELETE and GET handlers to validate client and additional client roles.
- Extend test cases to cover new client association scenarios.
- Ensure clients can only access projects they are associated with.
- Return 401 for unauthorized access attempts.
- Rename `CreateSemesterProjectRequestBody` to `CreateSemesterProjectRequestBodySchema`
- Add inferred type `CreateSemesterProjectRequestBody` from schema
- Update references to use the new schema name
- Adjust JSDoc formatting for consistency

**Fixes** #307 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
