### PR TITLE
195 Refactor auth to enable auth headers on development

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -42,7 +42,7 @@ export const POST = async (req: NextRequest) => {
       maxAge: 60 * 60,
     })
 
-    return NextResponse.json({ message: 'Login successful', redirect: `/${user.role}` })
+    return NextResponse.json({ message: 'Login successful', redirect: `/${user.role}`, token })
   } catch (error) {
     if (error instanceof ZodError) {
       return NextResponse.json(

--- a/src/business-layer/security/authentication.ts
+++ b/src/business-layer/security/authentication.ts
@@ -1,4 +1,4 @@
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 
 import AuthService from '../services/AuthService'
 import { JWTResponse } from '@/types/Middleware'
@@ -14,9 +14,20 @@ export class UnauthorizedAuthError extends Error {
 export async function payloadAuthentication(securityName: string, scopes?: string[]) {
   if (securityName === 'jwt') {
     const cookieStore = await cookies()
+    const headersList = await headers()
     return new Promise((resolve, reject) => {
       try {
-        const token = cookieStore.get(AUTH_COOKIE_NAME)?.value
+        let token: string = cookieStore.get(AUTH_COOKIE_NAME)?.value || ''
+
+        // Enable header based auth when NODE_ENV set the test mode
+        if (process.env.NODE_ENV !== 'production') {
+          console.log('yolo')
+          const authHeader = headersList.get('authorization') || ''
+          if (!token && !authHeader.startsWith('Bearer '))
+            return reject(new UnauthorizedAuthError('No token provided'))
+          else if (!token) token = authHeader.split(' ')[1] // Gets part after Bearer
+        }
+
         if (!token) return reject(new UnauthorizedAuthError('No token provided'))
         const authService = new AuthService()
         const decodedToken = authService.decodeJWT(token) as JWTResponse


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Include token in login API response for client-side use.
- Enable header-based authentication in non-production environments.
- Fallback to "Bearer" token from headers if cookie is unavailable.

**Fixes** #195 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="906" alt="image" src="https://github.com/user-attachments/assets/fcd8ee42-a6fa-447b-b6ea-c07a743a02c8" />

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
