### PR TITLE
453 frontend optimise data fetching for admin page

### DIFF
--- a/src/components/Composite/SemesterCard/SemesterCard.stories.tsx
+++ b/src/components/Composite/SemesterCard/SemesterCard.stories.tsx
@@ -24,7 +24,7 @@ export const CurrentSemester: Story = {
       return {
         data: [{ ...projectMock, semesters: [mockSemesters[1]] }],
       }
-    }
+    },
   },
 }
 

--- a/src/components/Composite/SemesterCard/SemesterCard.stories.tsx
+++ b/src/components/Composite/SemesterCard/SemesterCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import SemesterCard from './SemesterCard'
 import { mockSemesters } from '@/test-config/mocks/Semester.mock'
 import type { Semester } from '@/payload-types'
+import { projectMock } from '@/test-config/mocks/Project.mock'
 
 const mockProps: Semester = mockSemesters[0]
 
@@ -18,15 +19,24 @@ export const Default: Story = {}
 export const CurrentSemester: Story = {
   args: {
     ...Default.args,
-    name: 'Current Semester',
-    //currentOrUpcoming: 'current',
+    semester: mockSemesters[1],
+    handleGetAllSemesterProjects: async (semesterId: string) => {
+      return {
+        data: [{ ...projectMock, semesters: [mockSemesters[1]] }],
+      }
+    }
   },
 }
 
 export const UpcomingSemester: Story = {
   args: {
     ...Default.args,
-    name: 'Upcoming Semester',
-    //currentOrUpcoming: 'upcoming',
+    semester: mockSemesters[1],
+    handleGetAllSemesterProjects: async (semesterId: string) => {
+      return {
+        data: [{ ...projectMock, semesters: [mockSemesters[1]] }],
+      }
+    },
+    currentOrUpcoming: 'upcoming',
   },
 }

--- a/src/components/Composite/SemesterCard/SemesterCard.tsx
+++ b/src/components/Composite/SemesterCard/SemesterCard.tsx
@@ -16,7 +16,11 @@ interface SemesterCardProps extends Semester {
   }>
   currentOrUpcoming?: 'current' | 'upcoming' | ''
 }
-const SemesterCard: React.FC<SemesterCardProps> = ({ semester, handleGetAllSemesterProjects, currentOrUpcoming }) => {
+const SemesterCard: React.FC<SemesterCardProps> = ({
+  semester,
+  handleGetAllSemesterProjects,
+  currentOrUpcoming,
+}) => {
   const [isOpen, setIsOpen] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
   const [height, setHeight] = useState('0px')
@@ -32,7 +36,7 @@ const SemesterCard: React.FC<SemesterCardProps> = ({ semester, handleGetAllSemes
   }, [isOpen])
 
   const onOpen = async () => {
-    if (!isOpen){
+    if (!isOpen) {
       if (semester.id in semesterProjectRef.current) {
         return setSemesterProjects(semesterProjectRef.current[semester.id])
       }
@@ -51,7 +55,10 @@ const SemesterCard: React.FC<SemesterCardProps> = ({ semester, handleGetAllSemes
     <div className="relative w-full flex flex-col gap-4">
       {/* Semester Card */}
       <div
-        onClick={async () => { await onOpen(); setIsOpen(!isOpen)}} // should load projects
+        onClick={async () => {
+          await onOpen()
+          setIsOpen(!isOpen)
+        }} // should load projects
         className={`
       ${
         currentOrUpcoming === 'upcoming' || currentOrUpcoming === 'current'

--- a/src/components/Pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/components/Pages/AdminDashboard/AdminDashboard.tsx
@@ -15,6 +15,7 @@ import {
   updateProjectOrdersAndStatus,
   handleGetAllSemesters,
   getAllClients,
+  handleGetAllSemesterProjects,
 } from '@/lib/services/admin/Handlers'
 import SemestersPage from '../SemestersPage/SemestersPage'
 import ClientsPage from '../ClientsPage/ClientsPage'
@@ -27,7 +28,6 @@ type AdminDashboardProps = {
   projects: SemesterContainerData
   totalNumPages?: number
   semesterStatusList?: Record<string, 'current' | 'upcoming' | ''>
-  semesterProjects?: Record<string, ProjectDetails[]>
 }
 
 const AdminDashboard: React.FC<AdminDashboardProps> = ({
@@ -36,7 +36,6 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
   projects,
   totalNumPages = 0,
   semesterStatusList = {},
-  semesterProjects = {},
 }) => {
   const AdminNavElements = ['Projects', 'Clients', 'Semesters']
   const [activeNav, setActiveNav] = useState<number | null>(null)
@@ -250,8 +249,8 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
                   handleCreateSemester={handleCreateSemester}
                   handleUpdateSemester={handleUpdateSemester}
                   handleDeleteSemester={handleDeleteSemester}
+                  handleGetAllSemesterProjects = {handleGetAllSemesterProjects}
                   semesterStatuses={semesterStatuses}
-                  semesterProjects={semesterProjects}
                 />
               </div>
             </motion.div>

--- a/src/components/Pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/components/Pages/AdminDashboard/AdminDashboard.tsx
@@ -249,7 +249,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
                   handleCreateSemester={handleCreateSemester}
                   handleUpdateSemester={handleUpdateSemester}
                   handleDeleteSemester={handleDeleteSemester}
-                  handleGetAllSemesterProjects = {handleGetAllSemesterProjects}
+                  handleGetAllSemesterProjects={handleGetAllSemesterProjects}
                   semesterStatuses={semesterStatuses}
                 />
               </div>

--- a/src/components/Pages/AdminDashboard/ProtectedAdminView.tsx
+++ b/src/components/Pages/AdminDashboard/ProtectedAdminView.tsx
@@ -12,7 +12,6 @@ import type { SemesterContainerData } from '@/components/Composite/ProjectDragAn
 import NavBar from '@/components/Generic/NavBar/NavBar'
 import AdminDashboard from './AdminDashboard'
 import { handleLoginButtonClick } from '@/lib/services/user/Handlers'
-import type { ProjectDetails } from '@/types/Project'
 
 const ProtectedAdminView = async (): Promise<JSX.Element> => {
   const clientInfo = await ClientService.getClientInfo()
@@ -26,8 +25,6 @@ const ProtectedAdminView = async (): Promise<JSX.Element> => {
   const semestersData: Semester[] = fetchAllSemesters?.data || []
   const semesterStatuses: Record<string, 'current' | 'upcoming' | ''> =
     fetchAllSemesters?.semesterStatuses || {}
-  const semesterProjects: Record<string, ProjectDetails[]> =
-    fetchAllSemesters?.semesterProjects || {}
 
   const fetchProjects = await getNextSemesterProjects()
   const projectsData: SemesterContainerData = fetchProjects?.data || {
@@ -44,7 +41,6 @@ const ProtectedAdminView = async (): Promise<JSX.Element> => {
         projects={projectsData}
         totalNumPages={totalPages}
         semesterStatusList={semesterStatuses}
-        semesterProjects={semesterProjects}
       />
     </div>
   )

--- a/src/components/Pages/SemestersPage/SemestersPage.tsx
+++ b/src/components/Pages/SemestersPage/SemestersPage.tsx
@@ -32,9 +32,9 @@ interface SemestersPageProps {
     message?: string
   }>
   handleGetAllSemesterProjects: (semesterId: string) => Promise<void | {
-  error?: string
-  data?: ProjectDetails[]
-}>
+    error?: string
+    data?: ProjectDetails[]
+  }>
   semesterStatuses?: Record<string, 'current' | 'upcoming' | ''>
 }
 

--- a/src/components/Pages/SemestersPage/SemestersPage.tsx
+++ b/src/components/Pages/SemestersPage/SemestersPage.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react'
 import SemesterCard from '@/components/Composite/SemesterCard/SemesterCard'
 import Button from '@/components/Generic/Button/Button'
 import SemesterForm from '@/components/Composite/SemesterForm/SemesterForm'
-import type { Semester } from '@/payload-types'
+import type { Project, Semester } from '@/payload-types'
 import type { ProjectDetails } from '@/types/Project'
 import type { typeToFlattenedError } from 'zod'
 import type { CreateSemesterRequestBody } from '@/app/api/admin/semesters/route'
@@ -31,8 +31,11 @@ interface SemestersPageProps {
     error?: string
     message?: string
   }>
+  handleGetAllSemesterProjects: (semesterId: string) => Promise<void | {
+  error?: string
+  data?: ProjectDetails[]
+}>
   semesterStatuses?: Record<string, 'current' | 'upcoming' | ''>
-  semesterProjects?: Record<string, ProjectDetails[]>
 }
 
 const SemestersPage: React.FC<SemestersPageProps> = ({
@@ -43,8 +46,8 @@ const SemestersPage: React.FC<SemestersPageProps> = ({
   handleCreateSemester,
   handleUpdateSemester,
   handleDeleteSemester,
+  handleGetAllSemesterProjects,
   semesterStatuses = {},
-  semesterProjects = {},
 }) => {
   const [modalOpen, setModalOpen] = useState(false)
   const upcomingSemesterRef = useRef<HTMLDivElement>(null)
@@ -93,7 +96,7 @@ const SemestersPage: React.FC<SemestersPageProps> = ({
             updatedAt={semester.updatedAt}
             createdAt={semester.createdAt}
             currentOrUpcoming={semesterStatuses[semester.id] || ''}
-            semesterProjects={semesterProjects[semester.id] || []}
+            handleGetAllSemesterProjects={handleGetAllSemesterProjects}
           />
         </div>
       ))}

--- a/src/lib/services/admin/Handlers.ts
+++ b/src/lib/services/admin/Handlers.ts
@@ -99,7 +99,6 @@ export const handleGetAllSemesters = async (): Promise<void | {
   error?: string
   data?: Semester[]
   semesterStatuses?: Record<string, 'current' | 'upcoming' | ''>
-  semesterProjects?: Record<string, ProjectDetails[]>
 }> => {
   const { status, error, data } = await AdminService.getAllSemesters()
   if (status === 200) {
@@ -108,10 +107,8 @@ export const handleGetAllSemesters = async (): Promise<void | {
     for (const semester of data || []) {
       const status = await isCurrentOrUpcoming(semester.id)
       semesterStatuses[semester.id] = status
-      const projects = await handleGetAllSemesterProjects(semester.id)
-      semesterProjects[semester.id] = projects?.data || []
     }
-    return { data, semesterStatuses, semesterProjects }
+    return { data, semesterStatuses }
   } else {
     return { error }
   }


### PR DESCRIPTION
# Description

- Puts off data fetching for semester projects for until the user opens the semester modal
- caches semester api calls so the api will not be recalled if user reopens the semester modal

**Fixes** #453 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I have requested a review from another user
