### PR TITLE
fix(admin): delete user auth when deleting user

### DIFF
--- a/src/app/api/admin/semesters/[id]/projects/[projectId]/route.ts
+++ b/src/app/api/admin/semesters/[id]/projects/[projectId]/route.ts
@@ -9,13 +9,14 @@ import { Security } from '@/business-layer/middleware/Security'
 import type { SemesterProject } from '@/payload-types'
 import { ProjectSchema, SemesterSchema } from '@/types/Payload'
 import { ProjectStatus } from '@/types/Project'
+import type { UpdateSemesterProjectData } from '@/types/Collections'
 
 export const PatchSemesterProjectRequestBody = z.object({
   number: z.number().min(1).nullable().optional(),
   project: z.union([z.string(), ProjectSchema]).optional(),
   semester: z.union([z.string(), SemesterSchema]).optional(),
   status: z.nativeEnum(ProjectStatus).optional(),
-})
+}) satisfies z.ZodType<UpdateSemesterProjectData>
 
 class RouteWrapper {
   /**

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -8,6 +8,7 @@ import { UserRole } from '@/types/User'
 import type { UserCombinedInfo } from '@/types/Collections'
 import { Security } from '@/business-layer/middleware/Security'
 import ProjectDataService from '@/data-layer/services/ProjectDataService'
+import AuthDataService from '@/data-layer/services/AuthDataService'
 
 export const UpdateUserRequestBodySchema = z.object({
   firstName: z.string().optional(),
@@ -131,6 +132,7 @@ class RouteWrapper {
     const { id } = await params
     const userDataService = new UserDataService()
     const projectDataService = new ProjectDataService()
+    const authDataService = new AuthDataService()
 
     try {
       const clientAdditionalInfo = await userDataService.getClientAdditionalInfo(id)
@@ -153,7 +155,8 @@ class RouteWrapper {
         }),
       )
 
-      await userDataService.deleteUser(id)
+      const user = await userDataService.deleteUser(id)
+      await authDataService.deleteAuthByEmail(user.email)
 
       return new NextResponse(null, { status: StatusCodes.NO_CONTENT })
     } catch (error) {

--- a/src/data-layer/services/AuthDataService.test.ts
+++ b/src/data-layer/services/AuthDataService.test.ts
@@ -52,4 +52,10 @@ describe('Project service methods test', () => {
   it('should throw an error if auth does not exist', async () => {
     await expect(authDataService.deleteAuth('nonexistent_id')).rejects.toThrow('Not Found')
   })
+
+  it('should delete auth by email', async () => {
+    const newAuth = await authDataService.createAuth(authCreateMock)
+    await authDataService.deleteAuthByEmail(newAuth.email)
+    expect(await authDataService.getAuthByEmail(newAuth.email)).toBeUndefined()
+  })
 })

--- a/src/data-layer/services/AuthDataService.ts
+++ b/src/data-layer/services/AuthDataService.ts
@@ -79,4 +79,20 @@ export default class AuthDataService {
       id: authID,
     })
   }
+
+  /**
+   * Method to delete an authentication document by email.
+   *
+   * @param email The email of the authentication to delete
+   */
+  public async deleteAuthByEmail(email: string): Promise<void> {
+    await payload.delete({
+      collection: 'authentication',
+      where: {
+        email: {
+          equals: email,
+        },
+      },
+    })
+  }
 }

--- a/src/data-layer/services/UserDataService.ts
+++ b/src/data-layer/services/UserDataService.ts
@@ -115,7 +115,7 @@ export default class UserDataService {
    * Deletes a user from the database.
    *
    * @param userID the ID of the user to delete
-   * @returns A user document
+   * @returns The deleted {@link User} document
    */
   public async deleteUser(userID: string): Promise<User> {
     return await payload.delete({

--- a/src/data-layer/services/UserDataService.ts
+++ b/src/data-layer/services/UserDataService.ts
@@ -117,8 +117,8 @@ export default class UserDataService {
    * @param userID the ID of the user to delete
    * @returns A user document
    */
-  public async deleteUser(userID: string): Promise<void> {
-    await payload.delete({
+  public async deleteUser(userID: string): Promise<User> {
+    return await payload.delete({
       collection: 'user',
       id: userID,
     })


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Now deletes User Authentication object when admins call the DELETE user endpoint. 

**Fixes** # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
