### PR TITLE
feat: set admin title for collections

### DIFF
--- a/src/data-layer/collections/Authentication.ts
+++ b/src/data-layer/collections/Authentication.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from 'payload'
 
 export const Authentication: CollectionConfig = {
   slug: 'authentication',
+  admin: {
+    useAsTitle: 'email',
+  },
   access: {},
   fields: [
     {

--- a/src/data-layer/collections/Project.ts
+++ b/src/data-layer/collections/Project.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from 'payload'
 
 export const Project: CollectionConfig = {
   slug: 'project',
+  admin: {
+    useAsTitle: 'name',
+  },
   fields: [
     {
       name: 'name',

--- a/src/data-layer/collections/Semester.ts
+++ b/src/data-layer/collections/Semester.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from 'payload'
 
 export const Semester: CollectionConfig = {
   slug: 'semester',
+  admin: {
+    useAsTitle: 'name',
+  },
   fields: [
     {
       name: 'name',

--- a/src/data-layer/collections/SemesterProject.ts
+++ b/src/data-layer/collections/SemesterProject.ts
@@ -3,6 +3,9 @@ import { ProjectStatus } from '@/types/Project'
 
 export const SemesterProject: CollectionConfig = {
   slug: 'semesterProject',
+  admin: {
+    useAsTitle: 'project',
+  },
   fields: [
     {
       name: 'number',

--- a/src/data-layer/collections/User.ts
+++ b/src/data-layer/collections/User.ts
@@ -3,6 +3,9 @@ import { UserRole } from '@/types/User'
 
 export const User: CollectionConfig = {
   slug: 'user',
+  admin: {
+    useAsTitle: 'email',
+  },
   fields: [
     {
       name: 'email',


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

This fixes the problem of having to look through Payload Admin panel with IDs, this PR replaces the document IDs with the actual useful information such as a `Project` name, or `User` email. 

**Fixes** #492 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/7a5cdb90-fa0e-43ac-aff6-8d3325a498e5)

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
